### PR TITLE
feat: add GitLab authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5895,6 +5895,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/passport-gitlab2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/passport-gitlab2/-/passport-gitlab2-5.0.0.tgz",
+      "integrity": "sha512-cXQMgM6JQx9wHVh7JLH30D8fplfwjsDwRz+zS0pqC8JS+4bNmc1J04NGp5g2M4yfwylH9kQRrMN98GxMw7q7cg==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/passport-google-oauth20": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
@@ -8840,6 +8852,7 @@
         "open-collaboration-protocol": "0.2.0",
         "passport": "~0.7.0",
         "passport-github": "~1.1.0",
+        "passport-gitlab2": "^5.0.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-oauth2": "~1.6.1",
         "reflect-metadata": "^0.1.13",

--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -26,5 +26,6 @@ Environment variables
 | OCT_ACTIVATE_SIMPLE_LOGIN | Activates the simple login handler to alow unverified authentication just with username and optionally email |
 | OCT_OAUTH_{Provider Name}_CLIENTID | Sets the client id for the specified OAuth provider |
 | OCT_OAUTH_{Provider Name}_CLIENTSECRET | Sets the client secret for the specified OAuth provider |
+| OCT_OAUTH_GITLAB_BASE     | Overrides the base url for GitLab OAuth, e.g. in case you have a self-hosted instance |
 | OCT_REDIRECT_URL_WHITELIST | A comma seperated list to allow usage of the specified URLs with the `redirect` query parameter when authenticating with a provider which redirects back after success |
 

--- a/packages/open-collaboration-server/package.json
+++ b/packages/open-collaboration-server/package.json
@@ -22,6 +22,7 @@
     "passport": "~0.7.0",
     "passport-github": "~1.1.0",
     "passport-google-oauth20": "^2.0.0",
+    "passport-gitlab2": "^5.0.0",
     "passport-oauth2": "~1.6.1",
     "reflect-metadata": "^0.1.13",
     "semver": "^7.6.2",

--- a/packages/open-collaboration-server/src/@types/passport-gitlab.d.ts
+++ b/packages/open-collaboration-server/src/@types/passport-gitlab.d.ts
@@ -1,0 +1,30 @@
+declare module 'passport-gitlab2' {
+    import * as oauth2 from "passport-oauth2";
+
+    type StrategyOption = {
+        clientID: string,
+        clientSecret: string,
+        callbackURL: string,
+        baseURL?: string
+    }
+
+    type Profile = {
+       provider: string
+       id: string
+       username: string
+       displayName: string
+       emails: [{
+        value: string
+       }]
+       avatarUrl: string
+       profileUrl: string
+    }
+
+    declare class Strategy extends oauth2.Strategy {
+        constructor(options: StrategyOption, verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+    }
+
+    export {
+        Strategy
+    }
+}

--- a/packages/open-collaboration-server/src/container.ts
+++ b/packages/open-collaboration-server/src/container.ts
@@ -15,7 +15,7 @@ import { UserManager } from './user-manager';
 import { ConsoleLogger, LogLevel, LogLevelSymbol, LoggerSymbol } from './utils/logging';
 import { SimpleLoginEndpoint } from './auth-endpoints/simple-login-endpoint';
 import { AuthEndpoint } from './auth-endpoints/auth-endpoint';
-import { GitHubOAuthEndpoint, GoogleOAuthEndpoint  } from './auth-endpoints/oauth-endpoint';
+import { GitHubOAuthEndpoint, GoogleOAuthEndpoint, GitlabOAuthEndpoint } from './auth-endpoints/oauth-endpoint';
 import { Configuration, DefaultConfiguration } from './utils/configuration';
 import { PeerManager } from './peer-manager';
 
@@ -44,4 +44,6 @@ export default new ContainerModule(bind => {
     bind(AuthEndpoint).toService(GitHubOAuthEndpoint);
     bind(GoogleOAuthEndpoint).toSelf().inSingletonScope();
     bind(AuthEndpoint).toService(GoogleOAuthEndpoint);
+    bind(GitlabOAuthEndpoint).toSelf().inSingletonScope();
+    bind(AuthEndpoint).toService(GitlabOAuthEndpoint);
 });


### PR DESCRIPTION
This PR follows the given pattern for the already existing OIDC providers Github and Google and adds GitLab.