### PR TITLE
Adding the server URL to the invitation code using “@”.

### DIFF
--- a/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
@@ -24,8 +24,13 @@ export class CollaborationConnectionProvider {
     private fetch: typeof fetch;
 
     async createConnection(userToken?: string): Promise<ConnectionProvider | undefined> {
-        const serverUrl = vscode.workspace.getConfiguration().get<string>('oct.serverUrl');
         userToken ??= await this.context.secrets.get(OCT_USER_TOKEN);
+        let serverUrl;
+        if (userToken?.includes('\n')) {
+            [userToken, serverUrl] = userToken.split('\n');
+        } else {
+            serverUrl = vscode.workspace.getConfiguration().get<string>('oct.serverUrl');
+        }
 
         if (serverUrl) {
             return new ConnectionProvider({

--- a/packages/open-collaboration-vscode/src/collaboration-room-service.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-room-service.ts
@@ -105,13 +105,12 @@ export class CollaborationRoomService {
             }
         }
 
-        let url = undefined, br_url = "";
+        let url = undefined, br_url = '';
         if (roomId.includes('@@')) {
             [roomId, url] = roomId.split('@@');
             url = url.includes('://') ? url : `http://${url}`;
             br_url = `\n${url}`;
         } else if (roomId.includes('@')) {
-            let url
             [roomId, url] = roomId.split('@');
             url = url.includes('://') ? url : `https://${url}`;
             br_url = `\n${url}`;

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -9,13 +9,12 @@ import { inject, injectable } from 'inversify';
 import { FollowService } from './follow-service';
 import { CollaborationInstance, PeerWithColor } from './collaboration-instance';
 import { ExtensionContext } from './inversify';
-import { CollaborationConnectionProvider, OCT_USER_TOKEN } from './collaboration-connection-provider';
+import { OCT_USER_TOKEN } from './collaboration-connection-provider';
 import { QuickPickItem, showQuickPick } from './utils/quick-pick';
 import { ContextKeyService } from './context-key-service';
 import { CollaborationRoomService } from './collaboration-room-service';
 import { CollaborationStatusService } from './collaboration-status-service';
 import { closeSharedEditors, removeWorkspaceFolders } from './utils/workspace';
-import { ConnectionProvider } from 'open-collaboration-protocol';
 
 @injectable()
 export class Commands {
@@ -29,9 +28,6 @@ export class Commands {
     @inject(ContextKeyService)
     private contextKeyService: ContextKeyService;
 
-    @inject(CollaborationConnectionProvider)
-    private connectionProvider: CollaborationConnectionProvider;
-
     @inject(CollaborationRoomService)
     private roomService: CollaborationRoomService;
 
@@ -43,73 +39,67 @@ export class Commands {
             vscode.commands.registerCommand('oct.followPeer', (peer?: PeerWithColor) => this.followService.followPeer(peer?.id)),
             vscode.commands.registerCommand('oct.stopFollowPeer', () => this.followService.unfollowPeer()),
             vscode.commands.registerCommand('oct.enter', async () => {
-                this.withConnectionProvider(async connectionProvider => {
-                    const instance = CollaborationInstance.Current;
-                    if (instance) {
-                        const items: QuickPickItem<'invite' | 'stop'>[] = [
-                            {
-                                key: 'invite',
-                                label: '$(clippy) ' + vscode.l10n.t('Invite Others (Copy Code)'),
-                                detail: vscode.l10n.t('Copy the invitation code to the clipboard to share with others')
-                            }
-                        ];
-                        if (instance.host) {
-                            items.push({
-                                key: 'stop',
-                                label: '$(circle-slash) ' + vscode.l10n.t('Stop Collaboration Session'),
-                                detail: vscode.l10n.t('Stop the collaboration session, stop sharing all content and remove all participants')
-                            });
-                        } else {
-                            items.push({
-                                key: 'stop',
-                                label: '$(circle-slash) ' + vscode.l10n.t('Leave Collaboration Session'),
-                                detail: vscode.l10n.t('Leave the collaboration session, closing the current workspace')
-                            });
+                const instance = CollaborationInstance.Current;
+                if (instance) {
+                    const items: QuickPickItem<'invite' | 'stop'>[] = [
+                        {
+                            key: 'invite',
+                            label: '$(clippy) ' + vscode.l10n.t('Invite Others (Copy Code)'),
+                            detail: vscode.l10n.t('Copy the invitation code to the clipboard to share with others')
                         }
-                        const result = await showQuickPick(items, {
-                            placeholder: vscode.l10n.t('Select Collaboration Option')
+                    ];
+                    if (instance.host) {
+                        items.push({
+                            key: 'stop',
+                            label: '$(circle-slash) ' + vscode.l10n.t('Stop Collaboration Session'),
+                            detail: vscode.l10n.t('Stop the collaboration session, stop sharing all content and remove all participants')
                         });
-                        if (result === 'invite') {
-                            vscode.env.clipboard.writeText(instance.roomId);
-                            vscode.window.showInformationMessage(vscode.l10n.t('Invitation code {0} copied to clipboard!', instance.roomId));
-                        } else if (result === 'stop') {
-                            vscode.commands.executeCommand('oct.closeConnection');
-                        }
                     } else {
-                        const items: QuickPickItem<'join' | 'create'>[] = [
-                            {
-                                key: 'join',
-                                label: '$(vm-connect) ' + vscode.l10n.t('Join Collaboration Session'),
-                                detail: vscode.l10n.t('Join an open collaboration session using an invitation code')
-                            }
-                        ];
-                        if (vscode.workspace.workspaceFolders?.length) {
-                            items.unshift({
-                                key: 'create',
-                                label: '$(add) ' + vscode.l10n.t('Create New Collaboration Session'),
-                                detail: vscode.l10n.t('Become the host of a new collaboration session in your current workspace')
-                            });
-                        }
-                        const index = await showQuickPick(items, {
-                            placeholder: vscode.l10n.t('Select Collaboration Option')
+                        items.push({
+                            key: 'stop',
+                            label: '$(circle-slash) ' + vscode.l10n.t('Leave Collaboration Session'),
+                            detail: vscode.l10n.t('Leave the collaboration session, closing the current workspace')
                         });
-                        if (index === 'create') {
-                            await this.roomService.createRoom(connectionProvider);
-                        } else if (index === 'join') {
-                            await this.roomService.joinRoom(connectionProvider);
-                        }
                     }
-                });
+                    const result = await showQuickPick(items, {
+                        placeholder: vscode.l10n.t('Select Collaboration Option')
+                    });
+                    if (result === 'invite') {
+                        vscode.env.clipboard.writeText(instance.roomId);
+                        vscode.window.showInformationMessage(vscode.l10n.t('Invitation code {0} copied to clipboard!', instance.roomId));
+                    } else if (result === 'stop') {
+                        vscode.commands.executeCommand('oct.closeConnection');
+                    }
+                } else {
+                    const items: QuickPickItem<'join' | 'create'>[] = [
+                        {
+                            key: 'join',
+                            label: '$(vm-connect) ' + vscode.l10n.t('Join Collaboration Session'),
+                            detail: vscode.l10n.t('Join an open collaboration session using an invitation code')
+                        }
+                    ];
+                    if (vscode.workspace.workspaceFolders?.length) {
+                        items.unshift({
+                            key: 'create',
+                            label: '$(add) ' + vscode.l10n.t('Create New Collaboration Session'),
+                            detail: vscode.l10n.t('Become the host of a new collaboration session in your current workspace')
+                        });
+                    }
+                    const index = await showQuickPick(items, {
+                        placeholder: vscode.l10n.t('Select Collaboration Option')
+                    });
+                    if (index === 'create') {
+                        await this.roomService.createRoom();
+                    } else if (index === 'join') {
+                        await this.roomService.joinRoom();
+                    }
+                }
             }),
             vscode.commands.registerCommand('oct.joinRoom', async () => {
-                await this.withConnectionProvider(async connectionProvider => {
-                    await this.roomService.joinRoom(connectionProvider);
-                });
+                await this.roomService.joinRoom();
             }),
             vscode.commands.registerCommand('oct.createRoom', async () => {
-                await this.withConnectionProvider(async connectionProvider => {
-                    await this.roomService.createRoom(connectionProvider);
-                });
+                await this.roomService.createRoom();
             }),
             vscode.commands.registerCommand('oct.closeConnection', async () => {
                 const instance = CollaborationInstance.Current;
@@ -131,20 +121,4 @@ export class Commands {
         );
         this.statusService.initialize('oct.enter');
     }
-
-    private async withConnectionProvider(callback: (connectionProvider: ConnectionProvider) => (Promise<void> | void)): Promise<void> {
-        const connectionProvider = await this.connectionProvider.createConnection();
-        if (connectionProvider) {
-            await callback(connectionProvider);
-        } else {
-            const message = vscode.l10n.t('No Open Collaboration Server configured. Please set the server URL in the settings.');
-            const openSettings = vscode.l10n.t('Open Settings');
-            vscode.window.showInformationMessage(message, openSettings).then((selection) => {
-                if (selection === openSettings) {
-                    vscode.commands.executeCommand('workbench.action.openSettings', 'oct.serverUrl');
-                }
-            });
-        }
-    }
-
 }


### PR DESCRIPTION
Closes #82

It can temporarily overwrite oct.serverUrl by writing the `invitation code@URL.`
And “https://” can be omitted, and “http://” can be omitted if “@@” is used.

It is the roomId that is entered in joinroom, but due to the structure of connecting to the server using userToken and then entering the room with the roomId, it was necessary to re-store it in the userToken.

Also, in joinroom, the inputbox was displayed after connecting to the server withConnectionProvider, but we changed the order to withConnectionProvider according to the inputbox, I also changed the location of withConnectionProvider.