### PR TITLE
Revised login flow

### DIFF
--- a/packages/open-collaboration-protocol/src/connection-provider.ts
+++ b/packages/open-collaboration-protocol/src/connection-provider.ts
@@ -21,7 +21,7 @@ export interface ConnectionProviderOptions {
     client?: string;
     protocolVersion?: string;
     fetch: Fetch;
-    opener: (url: string) => void;
+    authenticationHandler: (token: string, authenticationMetadata: types.AuthMetadata) => void;
     transports: MessageTransportProvider[];
 }
 
@@ -114,9 +114,12 @@ export class ConnectionProvider {
             throw new Error('Invalid login response');
         }
         const confirmToken = loginBody.pollToken;
-        const url = loginBody.url;
-        const fullUrl = url.startsWith('/') ? this.getUrl(url) : url;
-        this.options.opener(fullUrl);
+        const url = loginBody.authMetadata.loginPageUrl;
+        const fullUrl = url?.startsWith('/') ? this.getUrl(url) : url;
+        this.options.authenticationHandler(confirmToken, {
+            ...loginBody.authMetadata,
+            loginPageUrl: fullUrl,
+        });
         const authToken = await this.pollLogin(confirmToken, options);
         this.userAuthToken = authToken;
         return authToken;

--- a/packages/open-collaboration-protocol/src/types.ts
+++ b/packages/open-collaboration-protocol/src/types.ts
@@ -68,7 +68,7 @@ export interface AuthProviderMetadata {
     endpoint: string;
 }
 
-export interface FormAuthProviderCongifuration extends AuthProviderMetadata {
+export interface FormAuthProviderConfiguration extends AuthProviderMetadata {
     type: 'form';
     fields: string[];
 }

--- a/packages/open-collaboration-protocol/src/types.ts
+++ b/packages/open-collaboration-protocol/src/types.ts
@@ -44,16 +44,33 @@ export namespace LoginValidateResponse {
 
 export interface LoginInitialResponse {
     pollToken: string;
-    url: string;
+    authMetadata: AuthMetadata;
 }
 
 export namespace LoginInitialResponse {
     export function is(arg: unknown): arg is LoginInitialResponse {
-        return isObject<LoginInitialResponse>(arg) && typeof arg.pollToken === 'string' && typeof arg.url === 'string';
+        return isObject<LoginInitialResponse>(arg) && typeof arg.pollToken === 'string' && typeof arg.authMetadata === 'object';
     }
-    export function create(pollToken: string, url: string): LoginInitialResponse {
-        return { pollToken, url };
+    export function create(pollToken: string, authMetadata: AuthMetadata): LoginInitialResponse {
+        return { pollToken, authMetadata };
     }
+}
+
+export interface AuthMetadata {
+    providers: AuthProviderMetadata[];
+    loginPageUrl?: string;
+    defaultSuccessUrl?: string;
+}
+
+export interface AuthProviderMetadata {
+    label: string;
+    type: string;
+    endpoint: string;
+}
+
+export interface FormAuthProviderCongifuration extends AuthProviderMetadata {
+    type: 'form';
+    fields: string[];
 }
 
 export interface LoginPollResponse {

--- a/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
@@ -5,7 +5,7 @@
 // ******************************************************************************
 
 import type { Express } from 'express';
-import { Event } from 'open-collaboration-protocol';
+import { AuthProviderMetadata, Event } from 'open-collaboration-protocol';
 import { User } from '../types';
 
 export type UserInfo = Omit<User, 'id'>;
@@ -20,4 +20,5 @@ export interface AuthEndpoint {
     shouldActivate(): boolean;
     onStart(app: Express, hostname: string, port: number): void;
     onDidAuthenticate: Event<AuthSuccessEvent>;
+    getMetadata(): AuthProviderMetadata;
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -13,6 +13,7 @@ import { Strategy as GithubStrategy } from 'passport-github';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Logger, LoggerSymbol } from '../utils/logging';
 import { Configuration } from '../utils/configuration';
+import { URL } from 'url';
 
 export const oauthProviders = Symbol('oauthProviders');
 
@@ -95,7 +96,7 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
                         res.status(400);
                         res.send('Error: Redirect URL not in whitelist');
                     } else {
-                        const url = URL.parse(redirectRequest);
+                        const url = URL.canParse(redirectRequest) ? new URL(redirectRequest) : undefined;
                         if(!url) {
                             res.status(400);
                             res.send('Error: Invalid redirect URL');

--- a/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
@@ -6,7 +6,7 @@
 
 import { inject, injectable } from 'inversify';
 import { type Express } from 'express';
-import { AuthProviderMetadata, Emitter, FormAuthProviderCongifuration } from 'open-collaboration-protocol';
+import { AuthProviderMetadata, Emitter, FormAuthProviderConfiguration } from 'open-collaboration-protocol';
 import { AuthEndpoint, AuthSuccessEvent } from './auth-endpoint';
 import { Logger, LoggerSymbol } from '../utils/logging';
 import { Configuration } from '../utils/configuration';
@@ -33,7 +33,7 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
             type: 'form',
             endpoint: SimpleLoginEndpoint.ENDPOINT,
             fields: ['user', 'email']
-        } as FormAuthProviderCongifuration;
+        } as FormAuthProviderConfiguration;
     }
 
     onStart(app: Express, _hostname: string, _port: number): void {

--- a/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
@@ -42,7 +42,7 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
                 const token = req.body.token as string;
                 const user = req.body.user as string;
                 const email = req.body.email as string | undefined;
-                await this.authSuccessEmitter.fire({token, userInfo: {name: user, email, authProvider: 'Unverified'}});
+                await Promise.all(this.authSuccessEmitter.fire({token, userInfo: {name: user, email, authProvider: 'Unverified'}}));
                 res.send('Ok');
             } catch (err) {
                 this.logger.error('Failed to perform simple login', err);

--- a/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
@@ -6,13 +6,15 @@
 
 import { inject, injectable } from 'inversify';
 import { type Express } from 'express';
-import { Emitter } from 'open-collaboration-protocol';
+import { AuthProviderMetadata, Emitter, FormAuthProviderCongifuration } from 'open-collaboration-protocol';
 import { AuthEndpoint, AuthSuccessEvent } from './auth-endpoint';
 import { Logger, LoggerSymbol } from '../utils/logging';
 import { Configuration } from '../utils/configuration';
 
 @injectable()
 export class SimpleLoginEndpoint implements AuthEndpoint {
+
+    protected static readonly ENDPOINT = '/api/login/simple';
 
     @inject(LoggerSymbol) protected logger: Logger;
 
@@ -25,8 +27,17 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
         return this.configuration.getValue('oct-activate-simple-login', 'boolean') ?? false;
     }
 
+    getMetadata(): AuthProviderMetadata {
+        return {
+            label: 'Unverified',
+            type: 'form',
+            endpoint: SimpleLoginEndpoint.ENDPOINT,
+            fields: ['user', 'email']
+        } as FormAuthProviderCongifuration;
+    }
+
     onStart(app: Express, _hostname: string, _port: number): void {
-        app.post('/api/login/simple', async (req, res) => {
+        app.post(SimpleLoginEndpoint.ENDPOINT, async (req, res) => {
             try {
                 const token = req.body.token as string;
                 const user = req.body.user as string;

--- a/packages/open-collaboration-server/src/collaboration-server.ts
+++ b/packages/open-collaboration-server/src/collaboration-server.ts
@@ -184,7 +184,11 @@ export class CollaborationServer {
                 }
                 const result: types.LoginInitialResponse = {
                     pollToken: token,
-                    url: loginPage
+                    authMetadata: {
+                        loginPageUrl: loginPage,
+                        providers: this.authEndpoints.map(endpoint => endpoint.getMetadata()),
+                        defaultSuccessUrl: this.configuration.getValue('oct-login-success-url') ?? ''
+                    }
                 };
                 res.status(200);
                 res.send(result);
@@ -268,7 +272,7 @@ export class CollaborationServer {
                 transports: [
                     // 'websocket',
                     'socket.io'
-                ]
+                ],
             };
             res.send(data);
         });

--- a/packages/open-collaboration-server/src/collaboration-server.ts
+++ b/packages/open-collaboration-server/src/collaboration-server.ts
@@ -93,10 +93,14 @@ export class CollaborationServer {
         for (const authEndpoint of this.authEndpoints) {
             if (authEndpoint.shouldActivate()) {
                 authEndpoint.onStart(app, String(args.hostname), Number(args.port));
-                authEndpoint.onDidAuthenticate(event =>
-                    this.credentials.confirmUser(event.token, event.userInfo)
-                        .catch(err => this.logger.error('Failed to confirm user', err))
-                );
+                authEndpoint.onDidAuthenticate(async event => {
+                    try {
+                        await this.credentials.confirmUser(event.token, event.userInfo);
+                    } catch (err) {
+                        this.logger.error('Failed to confirm user', err);
+                        throw new Error('Failed to confirm user');
+                    }
+                });
             }
         }
 

--- a/packages/open-collaboration-server/src/static/login.html
+++ b/packages/open-collaboration-server/src/static/login.html
@@ -26,7 +26,7 @@
         }
 
         button {
-            background-color: rgb(87, 114, 245);
+            background-color: #5772f5;
             border-radius: 5px;
             border: none;
             box-sizing: border-box;
@@ -55,6 +55,7 @@
             max-width: 600px;
             width: 100%;
             padding: 8px;
+            min-height: 200px;
         }
 
         .login-form {
@@ -72,31 +73,46 @@
             margin: 4px 12px;
         }
 
+        #error {
+            margin: 4px 12px;
+            color: #92140C;
+        }
+
+        .login-success {
+            text-align: center;
+        }
+
     </style>
     <script>
-        function login() {
+        async function login() {
             const token = new URLSearchParams(location.search).get('token');
             const user = document.getElementById('user').value;
             const email = document.getElementById('email').value;
-            fetch('/api/login/simple', {
+            const resp = await fetch('/api/login/simple', {
                 method: 'POST',
                 body: JSON.stringify({ user, email, token }),
                 headers: {
                     'Content-Type': 'application/json'
                 }
             });
+            if(resp.ok) {
+                document.getElementById('login-form').innerHTML = '<p class="login-success">Login successful. You can close this page now.<p>';
+            } else {
+                document.getElementById('error').style.visibility = 'visible';
+            }
         }
     </script>
 </head>
 
 <body>
     <div class="center-container">
-        <div class="card-box login-form">
+        <div class="card-box login-form" id="login-form">
             <span class="label">Username *</span>
             <input class="field" id="user">
             <span class="label">Email</span>
             <input class="field" id="email">
             <button class="submit" onclick="login()">Login</button>
+            <p style="visibility: hidden;" id="error">Error, could not login. Please try again.</p>
         </div>
     </div>
 </body>

--- a/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { inject, injectable } from 'inversify';
-import { ConnectionProvider, SocketIoTransportProvider } from 'open-collaboration-protocol';
+import { AuthProviderMetadata, ConnectionProvider, FormAuthProviderCongifuration, SocketIoTransportProvider } from 'open-collaboration-protocol';
 import { ExtensionContext } from './inversify';
 import { packageVersion } from './utils/package';
 
@@ -31,7 +31,23 @@ export class CollaborationConnectionProvider {
             return new ConnectionProvider({
                 url: serverUrl,
                 client: `OCT_CODE_${vscode.env.appName.replace(/\s+/, '_')}@${packageVersion}`,
-                opener: (url) => vscode.env.openExternal(vscode.Uri.parse(url)),
+                authenticationHandler: async (token, authMetadata) => {
+                    if(!authMetadata.providers?.length && authMetadata.loginPageUrl) {
+                        vscode.env.openExternal(vscode.Uri.parse(authMetadata.loginPageUrl));
+                        return;
+                    }
+                    const provider = await vscode.window.showQuickPick(authMetadata.providers, {title: vscode.l10n.t('Select authentication method')});
+                    if(provider) {
+                        switch(provider.type) {
+                            case 'form':
+                                this.handleFormAuth(token, provider as FormAuthProviderCongifuration, serverUrl);
+                                break;
+                            case 'oauth':
+                                this.handleOauthAuth(token, provider, serverUrl);
+                                break;
+                        }
+                    }
+                },
                 transports: [SocketIoTransportProvider],
                 userToken,
                 fetch: this.fetch
@@ -39,4 +55,38 @@ export class CollaborationConnectionProvider {
         }
         return undefined;
     }
+
+    private async handleFormAuth(token: string, provider: FormAuthProviderCongifuration, serverUrl: string) {
+        const fields = provider.fields;
+        const values:  Record<string, string> = {
+            token
+        };
+
+        for (const field of fields) {
+            const value = await vscode.window.showInputBox({
+                prompt: field,
+            });
+            if (value !== undefined) {
+                values[field] = value;
+            }
+        }
+
+        const endpointUrl = vscode.Uri.parse(serverUrl).with({path: provider.endpoint});
+        const response = await this.fetch(endpointUrl.toString(), {
+            method: 'POST',
+            body: JSON.stringify(values),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+        vscode.window.showInformationMessage(response.ok ? vscode.l10n.t('Login successful') : vscode.l10n.t('Login failed'));
+    }
+
+    private handleOauthAuth(token: string, provider: AuthProviderMetadata, serverUrl: string) {
+        const endpointUrl = vscode.Uri.parse(serverUrl).with({path: provider.endpoint, query: `token=${token}`});
+
+        vscode.env.openExternal(endpointUrl);
+
+    }
 }
+

--- a/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { inject, injectable } from 'inversify';
-import { AuthProviderMetadata, ConnectionProvider, FormAuthProviderCongifuration, SocketIoTransportProvider } from 'open-collaboration-protocol';
+import { AuthProviderMetadata, ConnectionProvider, FormAuthProviderConfiguration, SocketIoTransportProvider } from 'open-collaboration-protocol';
 import { ExtensionContext } from './inversify';
 import { packageVersion } from './utils/package';
 
@@ -40,7 +40,7 @@ export class CollaborationConnectionProvider {
                     if(provider) {
                         switch(provider.type) {
                             case 'form':
-                                this.handleFormAuth(token, provider as FormAuthProviderCongifuration, serverUrl);
+                                this.handleFormAuth(token, provider as FormAuthProviderConfiguration, serverUrl);
                                 break;
                             case 'oauth':
                                 this.handleOauthAuth(token, provider, serverUrl);
@@ -56,7 +56,7 @@ export class CollaborationConnectionProvider {
         return undefined;
     }
 
-    private async handleFormAuth(token: string, provider: FormAuthProviderCongifuration, serverUrl: string) {
+    private async handleFormAuth(token: string, provider: FormAuthProviderConfiguration, serverUrl: string) {
         const fields = provider.fields;
         const values:  Record<string, string> = {
             token


### PR DESCRIPTION
This PR revises the current login flow. 

- Having a specific website for authentication is now optional.
- All authentication provider now need to provide metadata which can be used by a client to handle the specific login flow
- the `redirect` query option for oauth based clients now adds the `pollToken` to the redirect url so that it possible for clients to to retrieve this on startup and through that retrieve the actual jwt. That makes it possible to redirect for authentication instead of opening a new tab for web based applications.
- improved unverified login page and error handling