### PR TITLE
Container image build and exec improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules/
+**/dist
+**/tsconfig.tsbuildinfo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,6 @@ services:
     ports:
       - 8100:8100
     container_name: oct-server
+    tty: true
+    environment:
+      - OCT_ACTIVATE_SIMPLE_LOGIN=true


### PR DESCRIPTION
The local build artifacts are not initially copied.
The simple login env flag is now set in the compose file