### PR TITLE
Use code-workspace files instead of adhoc workspace folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8919,6 +8919,7 @@
         "async-mutex": "^0.5.0",
         "inversify": "^6.0.2",
         "lodash": "^4.17.21",
+        "nanoid": "^5.1.4",
         "node-fetch": "^2.0.0",
         "open-collaboration-protocol": "0.2.0",
         "open-collaboration-yjs": "0.2.0",
@@ -9370,6 +9371,24 @@
         "@esbuild/win32-arm64": "0.23.1",
         "@esbuild/win32-ia32": "0.23.1",
         "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "packages/open-collaboration-vscode/node_modules/nanoid": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.4.tgz",
+      "integrity": "sha512-GTFcMIDgR7tqji/LpSY8rtg464VnJl/j6ypoehYnuGb+Y8qZUdtKB8WVCXon0UEZgFDbuUxpIl//6FHLHgXSNA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "packages/open-collaboration-vscode/node_modules/reflect-metadata": {

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -42,7 +42,8 @@
     "vscode": "^1.73.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onUri:oct"
   ],
   "capabilities": {
     "untrustedWorkspaces": {
@@ -221,6 +222,7 @@
     "open-collaboration-yjs": "0.2.0",
     "open-collaboration-protocol": "0.2.0",
     "lodash": "^4.17.21",
+    "nanoid": "^5.1.4",
     "node-fetch": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -14,7 +14,6 @@ import { QuickPickItem, showQuickPick } from './utils/quick-pick';
 import { ContextKeyService } from './context-key-service';
 import { CollaborationRoomService } from './collaboration-room-service';
 import { CollaborationStatusService } from './collaboration-status-service';
-import { closeSharedEditors, removeWorkspaceFolders } from './utils/workspace';
 import { ConnectionProvider } from 'open-collaboration-protocol';
 
 @injectable()
@@ -118,8 +117,8 @@ export class Commands {
                     instance.dispose();
                     this.contextKeyService.setConnection(undefined);
                     if (!instance.host) {
-                        await closeSharedEditors();
-                        removeWorkspaceFolders();
+                        // Close the workspace if the user is not the host
+                        await vscode.commands.executeCommand('workbench.action.closeFolder');
                     }
                 }
             }),

--- a/packages/open-collaboration-vscode/src/utils/workspace.ts
+++ b/packages/open-collaboration-vscode/src/utils/workspace.ts
@@ -6,6 +6,8 @@
 
 import * as vscode from 'vscode';
 import { CollaborationUri } from './uri';
+import { nanoid } from 'nanoid';
+import { isWeb } from './system';
 
 export function removeWorkspaceFolders() {
     const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
@@ -22,10 +24,52 @@ export function removeWorkspaceFolders() {
     }
 }
 
+export interface Folder {
+    uri: vscode.Uri;
+    name: string;
+}
+
+export interface CodeWorkspace {
+    folders: CodeWorkspaceFolder[];
+}
+
+export interface CodeWorkspaceFolder {
+    name: string;
+    uri: string;
+}
+
+export async function storeWorkspace(folders: Folder[], storageUri: vscode.Uri): Promise<vscode.Uri | undefined> {
+    const canWrite = vscode.workspace.fs.isWritableFileSystem(storageUri.scheme);
+    if (!canWrite || isWeb) {
+        return undefined;
+    }
+    try {
+        const uuid = nanoid(24);
+        const workspaceFileDir = storageUri.with({ path: storageUri.path + `/workspaces/${uuid}` });
+        const workspace: CodeWorkspace = {
+            folders: folders.map(folder => ({
+                name: folder.name,
+                uri: folder.uri.toString(true)
+            }))
+        };
+        await vscode.workspace.fs.createDirectory(workspaceFileDir);
+        const workspaceFile = workspaceFileDir.with({ path: workspaceFileDir.path + '/Open Collaboration.code-workspace' });
+        await vscode.workspace.fs.writeFile(workspaceFile, Buffer.from(JSON.stringify(workspace, undefined, 2)));
+        return workspaceFile;
+    } catch {
+        // In case of failure, the extension should replace the existing workspace folders with the new ones.
+        // This isn't ideal, but it's better than losing the workspace.
+        return undefined;
+    }
+}
+
 export async function closeSharedEditors(): Promise<void> {
-    await vscode.window.tabGroups.close(
-        vscode.window.tabGroups.all
-            .flatMap(group => group.tabs)
-            .filter(tab => (tab.input as { uri?: vscode.Uri }).uri?.scheme === CollaborationUri.SCHEME)
-    );
+    const tabInputs = vscode.window.tabGroups.all.flatMap(group => group.tabs);
+    const collabTabs = tabInputs.filter(tab => {
+        if (typeof tab.input === 'object' && tab.input && 'uri' in tab.input && tab.input.uri instanceof vscode.Uri) {
+            return tab.input.uri.scheme === CollaborationUri.SCHEME;
+        }
+        return false;
+    });
+    await vscode.window.tabGroups.close(collabTabs);
 }


### PR DESCRIPTION
Close https://github.com/eclipse-oct/open-collaboration-tools/issues/93

Instead of operating on the currently opened workspace (which we shouldn't do in the first place), this change creates a dedicated workspace file that is opened in the current VS Code window. That way we don't corrupt the existing workspace and also get better workspace handling in general (i.e. better naming, we don't get asked whether we want to save the workspace on close, etc.).