### PR TITLE
Fix VS Code editor desyncing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Monaco Examples",
-            "request": "launch",
-            "type": "chrome",
-            "url": "http://localhost:5173/",
-            "webRoot": "${workspaceFolder}/packages/open-collaboration-monaco",
-        },
-        {
             "type": "node",
             "request": "launch",
             "name": "Launch Server",
@@ -32,39 +25,65 @@
             }
         },
         {
-			"name": "Run VS Code Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}/packages/open-collaboration-vscode"
-			],
+            "name": "Run VS Code Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/packages/open-collaboration-vscode"
+            ],
+            "env": {
+                "DEVELOPMENT": "true"
+            },
             "sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/packages/open-collaboration-vscode/dist/**/*.js"
-			]
-		},
+            "outFiles": [
+                "${workspaceFolder}/packages/open-collaboration-vscode/dist/**/*.js"
+            ]
+        },
         {
-			"name": "Run VS Code Web Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}/packages/open-collaboration-vscode",
+            "name": "Run VS Code Web Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/packages/open-collaboration-vscode",
                 "--extensionDevelopmentKind=web"
-			],
+            ],
             // VS Code cannot debug the web extension directly, which is why we don't configure source maps here
             // Instead, use VS Code browser dev tools (Help -> Toggle Developer Tools) to debug the web extension
-		},
-    {
-      "name": "Launch Service Process",
-      "type": "node",
-      "request": "launch",
-      "console": "integratedTerminal",
-      "outFiles": [
-        "${workspaceFolder}/packages/open-collaboration-service-process/lib/**/*.js"
-      ],
-      "sourceMaps": true,
-      "program": "${workspaceFolder}/packages/open-collaboration-service-process/lib/process.js",
-      "args": ["--server-address=http://localhost:8100", "--auth-token=12312"]
-    }
+        },
+        {
+            "name": "Launch Service Process",
+            "type": "node",
+            "request": "launch",
+            "console": "integratedTerminal",
+            "outFiles": [
+                "${workspaceFolder}/packages/open-collaboration-service-process/lib/**/*.js"
+            ],
+            "sourceMaps": true,
+            "program": "${workspaceFolder}/packages/open-collaboration-service-process/lib/process.js",
+            "args": [
+                "--server-address=http://localhost:8100",
+                "--auth-token=12312"
+            ]
+        },
+        {
+            "name": "Debug Monaco Examples",
+            "request": "launch",
+            "type": "chrome",
+            "url": "http://localhost:5173/",
+            "webRoot": "${workspaceFolder}/packages/open-collaboration-monaco",
+        },
+        {
+            "name": "Vitest: Run Selected File",
+            "type": "node",
+            "request": "launch",
+            "autoAttachChildProcesses": true,
+            "skipFiles": ["<node_internals>/**", "**/node_modules/**", "!**/node_modules/vscode-*/**"],
+            "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+            "args": ["run", "${relativeFile}"],
+            "console": "integratedTerminal",
+            "smartStep": true,
+            "sourceMaps": true,
+            "outFiles": []
+        }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
       "engines": {
         "node": ">= 18.0.0",
         "npm": ">= 9.5.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -645,6 +648,253 @@
       "version": "1.0.0-next.28",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz",
+      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz",
+      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz",
+      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz",
+      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz",
+      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz",
+      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz",
+      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz",
+      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz",
+      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz",
+      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz",
+      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz",
+      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz",
+      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz",
+      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz",
+      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz",
+      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz",
+      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz",
+      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.37.0",
@@ -3605,6 +3855,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -6062,6 +6326,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
+      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/rollup/node_modules/@types/estree": {
       "version": "1.0.6",
       "license": "MIT"
@@ -7469,6 +7746,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
     "node_modules/web-tree-sitter": {
       "version": "0.20.8",
       "dev": true,
@@ -8078,6 +8361,7 @@
       "dependencies": {
         "lib0": "^0.2.94",
         "open-collaboration-protocol": "0.2.1",
+        "vscode-languageserver-textdocument": "1.0.12",
         "y-protocols": "^1.0.6"
       },
       "peerDependencies": {

--- a/packages/open-collaboration-monaco/src/collaboration-instance.ts
+++ b/packages/open-collaboration-monaco/src/collaboration-instance.ts
@@ -73,7 +73,9 @@ export class CollaborationInstance implements Disposable {
 
     constructor(protected options: CollaborationInstanceOptions) {
         const connection = options.connection;
-        this.yjsProvider = new OpenCollaborationYjsProvider(this.options.connection, this.yjs, this.yjsAwareness);
+        this.yjsProvider = new OpenCollaborationYjsProvider(this.options.connection, this.yjs, this.yjsAwareness, {
+            resyncTimer: 10_000
+        });
         this.yjsProvider.connect();
 
         connection.peer.onJoinRequest(async (_, user) => {

--- a/packages/open-collaboration-service-process/src/collaboration-instance.ts
+++ b/packages/open-collaboration-service-process/src/collaboration-instance.ts
@@ -45,7 +45,9 @@ export class CollaborationInstance implements types.Disposable{
                 this.yjsAwareness.destroy();
             }});
 
-        this.yjsProvider = new OpenCollaborationYjsProvider(currentConnection, this.YjsDoc, this.yjsAwareness);
+        this.yjsProvider = new OpenCollaborationYjsProvider(currentConnection, this.YjsDoc, this.yjsAwareness, {
+            resyncTimer: 10_000
+        });
         this.yjsProvider.connect();
         this.connectionDisposables.push(currentConnection.onReconnect(() => {
             this.yjsProvider?.connect();

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -94,18 +94,6 @@
         {
           "command": "oct.stopFollowPeer",
           "when": "oct.connection && oct.following"
-        },
-        {
-          "command": "oct.closeConnection",
-          "when": "oct.connection"
-        },
-        {
-          "command": "oct.joinRoom",
-          "when": "!oct.connection"
-        },
-        {
-          "command": "oct.createRoom",
-          "when": "workbenchState != empty && !oct.connection"
         }
       ],
       "view/item/context": [
@@ -123,6 +111,12 @@
     },
     "commands": [
       {
+        "command": "oct.dev.fuzzing",
+        "title": "Run Fuzzing Test",
+        "category": "Open Collaboration Tools Developer",
+        "enablement": "oct.dev"
+      },
+      {
         "command": "oct.followPeer",
         "title": "%oct.followPeer%",
         "category": "Open Collaboration Tools",
@@ -138,19 +132,22 @@
         "command": "oct.closeConnection",
         "title": "%oct.closeConnection%",
         "category": "Open Collaboration Tools",
-        "icon": "$(close)"
+        "icon": "$(close)",
+        "enablement": "oct.connection"
       },
       {
         "command": "oct.joinRoom",
         "title": "%oct.joinRoom%",
         "category": "Open Collaboration Tools",
-        "icon": "$(vm-connect)"
+        "icon": "$(vm-connect)",
+        "enablement": "!oct.connection"
       },
       {
         "command": "oct.createRoom",
         "title": "%oct.createRoom%",
         "category": "Open Collaboration Tools",
-        "icon": "$(vm-connect)"
+        "icon": "$(vm-connect)",
+        "enablement": "workbenchState != empty && !oct.connection"
       },
       {
         "command": "oct.signOut",

--- a/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-connection-provider.ts
@@ -25,7 +25,7 @@ export class CollaborationConnectionProvider {
         const userToken = await this.secretStorage.retrieveUserToken(serverUrl);
         return new ConnectionProvider({
             url: serverUrl,
-            client: `OCT_CODE_${vscode.env.appName.replace(/\s+/, '_')}@${packageVersion}`,
+            client: `OCT_CODE_${vscode.env.appName.replace(/[\s\-_]+/g, '_')}@${packageVersion}`,
             authenticationHandler: async (token, authMetadata) => {
                 if (!authMetadata.providers?.length && authMetadata.loginPageUrl) {
                     vscode.env.openExternal(vscode.Uri.parse(authMetadata.loginPageUrl));

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -130,6 +130,28 @@ export class Commands {
                 vscode.window.showInformationMessage(vscode.l10n.t('Signed out successfully!'));
             })
         );
+        if (typeof process === 'object' && process && process.env?.DEVELOPMENT === 'true') {
+            this.contextKeyService.set('oct.dev', true);
+            this.context.subscriptions.push(
+                vscode.commands.registerCommand('oct.dev.fuzzing', async () => {
+                    const editor = vscode.window.activeTextEditor;
+                    // Generate random character a-z
+                    const char = String.fromCharCode(Math.floor(Math.random() * 26) + 97);
+                    if (editor) {
+                        const interval = setInterval(() => {
+                            if (vscode.window.activeTextEditor !== editor) {
+                                // If the user changes the editor or closes it, end the fuzzing
+                                clearInterval(interval);
+                                return;
+                            }
+                            editor.edit(builder => {
+                                builder.insert(editor.selection.start, char);
+                            });
+                        }, 50);
+                    }
+                })
+            );
+        }
         this.statusService.initialize('oct.enter');
     }
 }

--- a/packages/open-collaboration-yjs/package.json
+++ b/packages/open-collaboration-yjs/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "lib0": "^0.2.94",
     "open-collaboration-protocol": "0.2.1",
+    "vscode-languageserver-textdocument": "1.0.12",
     "y-protocols": "^1.0.6"
   },
   "peerDependencies": {

--- a/packages/open-collaboration-yjs/src/index.ts
+++ b/packages/open-collaboration-yjs/src/index.ts
@@ -5,3 +5,4 @@
 // ******************************************************************************
 
 export * from './yjs-provider';
+export * from './ytext-change-tracker';

--- a/packages/open-collaboration-yjs/src/ytext-change-tracker.ts
+++ b/packages/open-collaboration-yjs/src/ytext-change-tracker.ts
@@ -1,0 +1,98 @@
+// ******************************************************************************
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+import * as Y from 'yjs';
+import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument';
+
+export interface YTextChange {
+    start: number;
+    end: number;
+    text: string;
+}
+
+export interface YTextChangeDelta {
+    insert?: string | object | Y.AbstractType<any>;
+    delete?: number;
+    retain?: number;
+    attributes?: Record<string, any>;
+}
+
+interface ChangeSet {
+    changes: YTextChange[];
+    document: TextDocument;
+}
+
+export class YTextChangeTracker {
+
+    private changeSets: ChangeSet[] = [];
+
+    async applyDelta(delta: YTextChangeDelta[], document: string, apply: (changes: YTextChange[]) => Promise<void>): Promise<void> {
+        const changes: YTextChange[] = [];
+        let index = 0;
+        for (const op of delta) {
+            if (typeof op.retain === 'number') {
+                index += op.retain;
+            } else if (typeof op.insert === 'string') {
+                changes.push({
+                    start: index,
+                    end: index,
+                    text: op.insert
+                });
+            } else if (typeof op.delete === 'number') {
+                changes.push({
+                    start: index,
+                    end: index + op.delete,
+                    text: ''
+                });
+                // Increase the index by the number of characters deleted
+                // In the client, every following operation will still operate on the "old code"
+                // So we need to adjust the index to reflect that
+                index += op.delete;
+            }
+        }
+        await this.applyChanges(changes, document, apply);
+    }
+
+    async applyChanges(changes: YTextChange[], document: string, apply: (changes: YTextChange[]) => Promise<void>): Promise<void> {
+        const changeSet: ChangeSet = {
+            changes: changes,
+            document: TextDocument.create('', '', 0, document)
+        };
+        this.changeSets.push(changeSet);
+        await apply(changes);
+        // Remove the change set from the list of pending changes, as it has been fully applied
+        const index = this.changeSets.indexOf(changeSet);
+        if (index !== -1) {
+            this.changeSets.splice(index, 1);
+        }
+    }
+
+    private toTextEdits(document: TextDocument, changes: YTextChange[]): TextEdit[] {
+        return changes.map(change => ({
+            newText: change.text,
+            range: {
+                start: document.positionAt(change.start),
+                end: document.positionAt(change.end)
+            }
+        }));
+    }
+
+    shouldApply(changes: YTextChange[]): boolean {
+        for (const changeSet of this.changeSets) {
+            // We use TextDocument.applyEdits for convenience here to check whether the changes lead to the same result
+            // We cannot simply compare the changes themselves, as they are merged together by the editor (in an unpredictable way)
+            const afterNewChange = TextDocument.applyEdits(changeSet.document, this.toTextEdits(changeSet.document, changes));
+            const afterExistingChanges = TextDocument.applyEdits(changeSet.document, this.toTextEdits(changeSet.document, changeSet.changes));
+            if (afterNewChange === afterExistingChanges) {
+                // If the changes lead to the same result, we can ignore them
+                // This is usually the case when we have found a change in the client that originates from the collaboration session
+                return false;
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
Closes https://github.com/eclipse-oct/open-collaboration-tools/issues/80

Performs a few adjustments to prevent the VS Code editors from desyncing. Does this on multiple levels:

1. Previously, we used an `update` flag to prevent edits to files that were currently being edited by our extension. This sometimes led to us dropping incoming updates from Yjs. This is no longer the case
2. In case we have dropped some Yjs updates anyway, Yjs will initiate a broadcast sync every 10 seconds.
3. Since we no longer have the `update` flag, all file operations are queued into a `YTextChangeTracker` that attempts to keep track of changes that we did (I.e. the extension performed) and those of the user. We only want to broadcast changes done by the user.
4. If the above fails, we use a resync throttle that attempts to resync the document with the document that is stored in Yjs.

All of this can be tested by running the `Open Collaboration Tools Developer: Start Fuzzing Test` command. Ideally you should use two instances of VS Code that are both running this command. Independent of the changes, the documents should (eventually, it might take a second sometimes) converge to one single text document.

Note that I've put the Microsoft Live Share extension through the same testing and was able to **desync two VS Code clients**, whereas the same testing setup in OCT eventually led to two identical VS Code editors.