### PR TITLE
Clean up package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A public instance of the collaboration server is available at [open-collab.tools
 
 [TypeFox](https://www.typefox.io/) offers this service with the intent to demonstrate the capabilities of the project and to support open source communities with it. However, we recommend all companies who wish to adopt this technology to deploy their own instance of it, secured with their existing access restrictions.
 
-Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/TypeFox/open-collaboration-tools/discussions) for any questions.
+Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/eclipse-oct/open-collaboration-tools/discussions) for any questions.
 
 ## IDE Extensions
 
@@ -44,7 +44,7 @@ npm run start
 
 ## Deployment
 
-A container image named [oct-server](https://github.com/TypeFox/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server) is available for simple deployment. It does not require any additional infrastructure services. However, the server uses WebSocket connections and holds session data in memory, so horizontal scaling is not yet supported.
+A container image named [oct-server](https://github.com/eclipse-oct/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server) is available for simple deployment. It does not require any additional infrastructure services. However, the server uses WebSocket connections and holds session data in memory, so horizontal scaling is not yet supported.
 
 Build the container image:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The following table indicates which versions of Open Collaboration Tools are sup
 
 The Open Collaboration Tools team and community take security bugs in Open Collaboration Tools seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/TypeFox/open-collaboration-tools/security/advisories/new) tab.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/eclipse-oct/open-collaboration-tools/security/advisories/new) tab.
 
 The Open Collaboration Tools team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8080,7 +8080,7 @@
       }
     },
     "packages/open-collaboration-monaco": {
-      "version": "0.2.4",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/open-collaboration-monaco/package.json
+++ b/packages/open-collaboration-monaco/package.json
@@ -1,42 +1,13 @@
 {
   "name": "open-collaboration-monaco",
-  "displayName": "OCT Monaco Client API",
-  "description": "Connect a single Monaco Editor to an Open Collaboration Tools session",
-  "version": "0.2.4",
-  "publisher": "typefox",
-  "type": "module",
-  "categories": [
-    "Other"
-  ],
-  "keywords": [
-    "collaboration",
-    "share",
-    "live-share",
-    "real-time",
-    "team",
-    "co-edit",
-    "pair-programming",
-    "monaco-editor"
-  ],
+  "version": "0.2.1",
   "license": "MIT",
-  "icon": "data/oct-logo.png",
-  "galleryBanner": {
-    "color": "#031021",
-    "theme": "dark"
-  },
-  "homepage": "https://www.open-collab.tools/",
-  "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
-    "directory": "packages/open-collaboration-monaco"
-  },
-  "author": {
-    "name": "TypeFox",
-    "url": "https://www.typefox.io/"
-  },
+  "description": "Connect a single Monaco Editor to an Open Collaboration Tools session",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "type": "module",
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "exports": {
@@ -65,5 +36,29 @@
     "@types/node-fetch": "^2.0.0",
     "@types/vscode": "^1.89.0",
     "@types/ws": "^8.5.10"
+  },
+  "keywords": [
+    "collaboration",
+    "live-share",
+    "real-time",
+    "pair-programming",
+    "monaco-editor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
+    "directory": "packages/open-collaboration-monaco"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
+  },
+  "homepage": "https://www.open-collab.tools/",
+  "author": {
+    "name": "TypeFox",
+    "url": "https://www.typefox.io/"
+  },
+  "volta": {
+    "node": "22.14.0",
+    "npm": "10.9.2"
   }
 }

--- a/packages/open-collaboration-protocol/package.json
+++ b/packages/open-collaboration-protocol/package.json
@@ -1,6 +1,7 @@
 {
   "name": "open-collaboration-protocol",
   "version": "0.2.1",
+  "license": "MIT",
   "description": "Open Collaboration Protocol implementation, part of the Open Collaboration Tools project",
   "files": [
     "lib",
@@ -12,6 +13,9 @@
     "types": "./lib/index.d.ts",
     "browser": "./lib/index-browser.js",
     "node": "./lib/index-node.js"
+  },
+  "scripts": {
+    "build": "echo 'open-collaboration-protocol: Nothing extra to build.'"
   },
   "dependencies": {
     "base64-js": "^1.5.1",
@@ -28,14 +32,13 @@
     "live-share",
     "protocol"
   ],
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
     "directory": "packages/open-collaboration-protocol"
   },
   "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
   },
   "homepage": "https://www.open-collab.tools/",
   "author": {
@@ -45,8 +48,5 @@
   "volta": {
     "node": "22.14.0",
     "npm": "10.9.2"
-  },
-  "scripts": {
-    "build": "echo 'open-collaboration-protocol: Nothing extra to build.'"
   }
 }

--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -4,13 +4,13 @@ Open Collaboration Tools is a collection of open source tools, libraries and ext
 
 This package is the server implementation for Open Collaboration Tools. All participants of a collaboration session must connect to the same server.
 
-You can run this package directly or use the public container image [oct-server](https://github.com/TypeFox/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server). If you'd like to customize the server, use this package as a TypeScript library and build your own application.
+You can run this package directly or use the public container image [oct-server](https://github.com/eclipse-oct/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server). If you'd like to customize the server, use this package as a TypeScript library and build your own application.
 
 ## The Public Instance
 
 A public instance of this server is available at `https://api.open-collab.tools/`, which is operated by [TypeFox](https://www.typefox.io/). TypeFox offers this service with the intent to demonstrate the capabilities of the project and to support open source communities with it. However, we recommend all companies who wish to adopt this technology to deploy their own instance of it, secured with their existing access restrictions.
 
-Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/TypeFox/open-collaboration-tools/discussions) for any questions.
+Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/eclipse-oct/open-collaboration-tools/discussions) for any questions.
 
 ## Configuration
 

--- a/packages/open-collaboration-server/package.json
+++ b/packages/open-collaboration-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "open-collaboration-server",
   "version": "0.2.0",
+  "license": "MIT",
   "description": "Open Collaboration Server implementation, part of the Open Collaboration Tools project",
   "files": [
     "bin",
@@ -46,14 +47,13 @@
     "live-share",
     "server"
   ],
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
     "directory": "packages/open-collaboration-server"
   },
   "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
   },
   "homepage": "https://www.open-collab.tools/",
   "author": {

--- a/packages/open-collaboration-service-process/package.json
+++ b/packages/open-collaboration-service-process/package.json
@@ -1,6 +1,7 @@
 {
   "name": "open-collaboration-service-process",
   "version": "0.2.0",
+  "license": "MIT",
   "description": "A service process for integrating non Typescript projects with the Open Collaboration Tools project",
   "files": [
     "bin",
@@ -27,14 +28,13 @@
     "collaboration",
     "live-share"
   ],
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
     "directory": "packages/open-collaboration-server"
   },
   "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
   },
   "homepage": "https://www.open-collab.tools/",
   "author": {

--- a/packages/open-collaboration-vscode/README.md
+++ b/packages/open-collaboration-vscode/README.md
@@ -12,52 +12,52 @@ For more information about this project, please [read the announcement](https://
 
 This extension needs a server instance to which all participants of a collaboration session connect. The server URL is configured with the setting `oct.serverUrl`. Its default is set to `https://api.open-collab.tools/`, which is a public instance operated by [TypeFox](https://www.typefox.io/). TypeFox offers this service with the intent to demonstrate the capabilities of the project and to support open source communities with it. However, we recommend all companies who wish to adopt this technology to deploy their own instance of it, secured with their existing access restrictions.
 
-Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/TypeFox/open-collaboration-tools/discussions) for any questions.
+Usage of the public instance is bound to its [Terms of Use](https://www.open-collab.tools/tos/). Please read them carefully and use our [Discussions](https://github.com/eclipse-oct/open-collaboration-tools/discussions) for any questions.
 
 ## Using the Extension
 This extension contributes support for the [Open Collaboration Protocol](https://open-collab.tools).
 
 ### Quickstart
 
-The extension adds a new "Share" item to the Status bar at the bottom of vscode, which allows managing your current sessions.  
+The extension adds a new "Share" item to the Status bar at the bottom of vscode, which allows managing your current sessions.
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/bf5769ab-508b-4a6a-a91e-48e9efa8d4a6" alt="share-icon" width="300"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/bf5769ab-508b-4a6a-a91e-48e9efa8d4a6" alt="share-icon" width="300"/>
 
 ### Hosting a session
 
 1. Click on the share item in the status bar
 2. A quickpick will open at the top where you will select "Create New Collaboration Session"
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/ae09888e-e22f-424e-b863-b5d5bdd628de" alt="share popup" width="600"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/ae09888e-e22f-424e-b863-b5d5bdd628de" alt="share popup" width="600"/>
 
-3. If you are not already authenticated with the configured server, VS Code will try to open the authentication page in your browser. Follow the steps to authenticate yourself.  
-4. When the authentication was successful, a message will appear in the bottom right with an invite code. Share that with whoever you wish to join your session.  
+3. If you are not already authenticated with the configured server, VS Code will try to open the authentication page in your browser. Follow the steps to authenticate yourself.
+4. When the authentication was successful, a message will appear in the bottom right with an invite code. Share that with whoever you wish to join your session.
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/c74d1618-9846-4919-8342-716f91c77f9a" alt="share popup" width="400"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/c74d1618-9846-4919-8342-716f91c77f9a" alt="share popup" width="400"/>
 
-5. Should you need to copy the token again, click the "Sharing" item in the bottom toolbar again. A quickpick will open allowing you to copy the token or close the current session.  
-6. When a user requests to join, a message will appear at the bottom prompting you to allow or decline the join request.  
+5. Should you need to copy the token again, click the "Sharing" item in the bottom toolbar again. A quickpick will open allowing you to copy the token or close the current session.
+6. When a user requests to join, a message will appear at the bottom prompting you to allow or decline the join request.
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/dcae527f-ccfe-466d-a27a-9bf37c978165" alt="join request" width="400"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/dcae527f-ccfe-466d-a27a-9bf37c978165" alt="join request" width="400"/>
 
 
 ### Joining
 
 1. After you aquired an invite code, click on the share item in the status bar and select
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/ae09888e-e22f-424e-b863-b5d5bdd628de" alt="share popup" width="600"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/ae09888e-e22f-424e-b863-b5d5bdd628de" alt="share popup" width="600"/>
 
-2. A quickpick will open prompting you to input the invite code you acquired previously.  
-3. If you are not already authenticated with the configured server, VS Code will try to open the authentication page in your browser. Follow the steps to authenticate yourself.  
+2. A quickpick will open prompting you to input the invite code you acquired previously.
+3. If you are not already authenticated with the configured server, VS Code will try to open the authentication page in your browser. Follow the steps to authenticate yourself.
 4. That's it! After that VSCode will connect to the hosts session
 5. If you want to leave the session, click the "Connected" item in the status bar and select "Close Current Session" to leave the session.
 
 ### Session UI
 
-<img src="https://github.com/TypeFox/open-collaboration-tools/assets/34068281/096c5ddd-026d-455c-9608-5c0febfca6d8" alt="share popup" width="400"/>
+<img src="https://github.com/eclipse-oct/open-collaboration-tools/assets/34068281/096c5ddd-026d-455c-9608-5c0febfca6d8" alt="share popup" width="400"/>
 
-After joining or hosting a session, you will find a new "Current Collaboration Session" widget in the explorer tab. 
+After joining or hosting a session, you will find a new "Current Collaboration Session" widget in the explorer tab.
 
-This widget lists all joined users and their respecive cursor colors. 
+This widget lists all joined users and their respecive cursor colors.
 
-Through the follow icon, you can jump to another user and automatically follow them when they change their active file.  
+Through the follow icon, you can jump to another user and automatically follow them when they change their active file.

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -1,8 +1,9 @@
 {
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
-  "description": "Connect with others and live-share your code in real-time collaboration sessions",
   "version": "0.2.4",
+  "license": "MIT",
+  "description": "Connect with others and live-share your code in real-time collaboration sessions",
   "publisher": "typefox",
   "categories": [
     "Other"
@@ -16,7 +17,6 @@
     "co-edit",
     "pair-programming"
   ],
-  "license": "MIT",
   "icon": "data/oct-logo.png",
   "galleryBanner": {
     "color": "#031021",
@@ -24,11 +24,11 @@
   },
   "homepage": "https://www.open-collab.tools/",
   "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
     "directory": "packages/open-collaboration-vscode"
   },
   "author": {

--- a/packages/open-collaboration-yjs/package.json
+++ b/packages/open-collaboration-yjs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "open-collaboration-yjs",
   "version": "0.2.0",
+  "license": "MIT",
   "description": "Open Collaboration Yjs integration, part of the Open Collaboration Tools project",
   "files": [
     "lib",
@@ -8,6 +9,9 @@
   ],
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "scripts": {
+    "build": "echo 'open-collaboration-yjs: Nothing extra to build.'"
+  },
   "dependencies": {
     "lib0": "^0.2.94",
     "open-collaboration-protocol": "0.2.1",
@@ -21,14 +25,13 @@
     "live-share",
     "yjs"
   ],
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TypeFox/open-collaboration-tools",
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools",
     "directory": "packages/open-collaboration-yjs"
   },
   "bugs": {
-    "url": "https://github.com/TypeFox/open-collaboration-tools/issues"
+    "url": "https://github.com/eclipse-oct/open-collaboration-tools/issues"
   },
   "homepage": "https://www.open-collab.tools/",
   "author": {
@@ -38,8 +41,5 @@
   "volta": {
     "node": "22.14.0",
     "npm": "10.9.2"
-  },
-  "scripts": {
-    "build": "echo 'open-collaboration-yjs: Nothing extra to build.'"
   }
 }


### PR DESCRIPTION
Remark: we should define package exports for the server and service process, too, so they can be used as libraries to create custom versions. This can be done together with #103.