### PR TITLE
Revert #108

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7746,6 +7746,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
     "node_modules/web-tree-sitter": {
       "version": "0.20.8",
       "dev": true,
@@ -8355,6 +8361,7 @@
       "dependencies": {
         "lib0": "^0.2.94",
         "open-collaboration-protocol": "0.2.1",
+        "vscode-languageserver-textdocument": "1.0.12",
         "y-protocols": "^1.0.6"
       },
       "peerDependencies": {

--- a/packages/open-collaboration-yjs/package.json
+++ b/packages/open-collaboration-yjs/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "lib0": "^0.2.94",
     "open-collaboration-protocol": "0.2.1",
+    "vscode-languageserver-textdocument": "1.0.12",
     "y-protocols": "^1.0.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
This reverts #108. I've noticed that this change actually leads to a minor regression with the fuzzing test. I'm not sure why, but using `vscode-languageserver-textdocument` seems to resolve this perfectly.

I might come back to this in the future, but since this is a fairly isolated change, I think it's alright to revert this for now and accept the (very slight) performance penalty that the offset-to-position transformation incurs.