### PR TITLE
Support readonly session mode

### DIFF
--- a/packages/open-collaboration-vscode/src/collaboration-room-service.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-room-service.ts
@@ -16,6 +16,7 @@ import { Settings } from './utils/settings';
 import { RoomData, SecretStorage } from './secret-storage';
 import { storeWorkspace } from './utils/workspace';
 import { ExtensionContext } from './inversify';
+import { CodeCommands } from './commands-list';
 
 @injectable()
 export class CollaborationRoomService {
@@ -153,7 +154,7 @@ export class CollaborationRoomService {
                         if (uri) {
                             // We were able to store the workspace folders in a file
                             // We now attempt to load that workspace file
-                            await vscode.commands.executeCommand('vscode.openFolder', uri, {
+                            await vscode.commands.executeCommand(CodeCommands.OpenFolder, uri, {
                                 forceNewWindow: false,
                                 forceReuseWindow: true,
                                 noRecentEntry: true
@@ -220,7 +221,7 @@ export class CollaborationRoomService {
         const openSettings = vscode.l10n.t('Open Settings');
         vscode.window.showInformationMessage(message, openSettings).then((selection) => {
             if (selection === openSettings) {
-                vscode.commands.executeCommand('workbench.action.openSettings', Settings.SERVER_URL);
+                vscode.commands.executeCommand(CodeCommands.OpenSettings, Settings.SERVER_URL);
             }
         });
     }

--- a/packages/open-collaboration-vscode/src/commands-list.ts
+++ b/packages/open-collaboration-vscode/src/commands-list.ts
@@ -1,0 +1,22 @@
+// ******************************************************************************
+// Copyright 2025 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+export namespace OctCommands {
+    export const FollowPeer = 'oct.followPeer';
+    export const StopFollowPeer = 'oct.stopFollowPeer';
+    export const Enter = 'oct.enter';
+    export const JoinRoom = 'oct.joinRoom';
+    export const CreateRoom = 'oct.createRoom';
+    export const CloseConnection = 'oct.closeConnection';
+    export const SignOut = 'oct.signOut';
+    export const DevFuzzing = 'oct.dev.fuzzing';
+}
+
+export namespace CodeCommands {
+    export const CloseFolder = 'workbench.action.closeFolder';
+    export const OpenSettings = 'workbench.action.openSettings';
+    export const OpenFolder = 'vscode.openFolder';
+}

--- a/packages/open-collaboration-vscode/src/commands.ts
+++ b/packages/open-collaboration-vscode/src/commands.ts
@@ -15,6 +15,7 @@ import { CollaborationRoomService } from './collaboration-room-service';
 import { CollaborationStatusService } from './collaboration-status-service';
 import { SecretStorage } from './secret-storage';
 import { RoomUri } from './utils/uri';
+import { CodeCommands, OctCommands } from './commands-list';
 
 @injectable()
 export class Commands {
@@ -39,80 +40,18 @@ export class Commands {
 
     initialize(): void {
         this.context.subscriptions.push(
-            vscode.commands.registerCommand('oct.followPeer', (peer?: PeerWithColor) => this.followService.followPeer(peer?.id)),
-            vscode.commands.registerCommand('oct.stopFollowPeer', () => this.followService.unfollowPeer()),
-            vscode.commands.registerCommand('oct.enter', async () => {
-                const instance = CollaborationInstance.Current;
-                if (instance) {
-                    const items: QuickPickItem<'invite' | 'stop'>[] = [
-                        {
-                            key: 'invite',
-                            label: '$(clippy) ' + vscode.l10n.t('Invite Others (Copy Code)'),
-                            detail: vscode.l10n.t('Copy the invitation code to the clipboard to share with others')
-                        }
-                    ];
-                    if (instance.host) {
-                        items.push({
-                            key: 'stop',
-                            label: '$(circle-slash) ' + vscode.l10n.t('Stop Collaboration Session'),
-                            detail: vscode.l10n.t('Stop the collaboration session, stop sharing all content and remove all participants')
-                        });
-                    } else {
-                        items.push({
-                            key: 'stop',
-                            label: '$(circle-slash) ' + vscode.l10n.t('Leave Collaboration Session'),
-                            detail: vscode.l10n.t('Leave the collaboration session, closing the current workspace')
-                        });
-                    }
-                    const result = await showQuickPick(items, {
-                        placeholder: vscode.l10n.t('Select Collaboration Option')
-                    });
-                    if (result === 'invite') {
-                        vscode.env.clipboard.writeText(instance.roomId);
-                        const copyWithServer = vscode.l10n.t('Copy with Server URL');
-                        vscode.window.showInformationMessage(vscode.l10n.t('Invitation code {0} copied to clipboard!', instance.roomId), copyWithServer).then(value => {
-                            if (value === copyWithServer) {
-                                vscode.env.clipboard.writeText(RoomUri.create({
-                                    roomId: instance.roomId,
-                                    serverUrl: instance.serverUrl
-                                }));
-                            }
-                        });
-                    } else if (result === 'stop') {
-                        vscode.commands.executeCommand('oct.closeConnection');
-                    }
-                } else {
-                    const items: QuickPickItem<'join' | 'create'>[] = [
-                        {
-                            key: 'join',
-                            label: '$(vm-connect) ' + vscode.l10n.t('Join Collaboration Session'),
-                            detail: vscode.l10n.t('Join an open collaboration session using an invitation code')
-                        }
-                    ];
-                    if (vscode.workspace.workspaceFolders?.length) {
-                        items.unshift({
-                            key: 'create',
-                            label: '$(add) ' + vscode.l10n.t('Create New Collaboration Session'),
-                            detail: vscode.l10n.t('Become the host of a new collaboration session in your current workspace')
-                        });
-                    }
-                    const index = await showQuickPick(items, {
-                        placeholder: vscode.l10n.t('Select Collaboration Option')
-                    });
-                    if (index === 'create') {
-                        await this.roomService.createRoom();
-                    } else if (index === 'join') {
-                        await this.roomService.joinRoom();
-                    }
-                }
+            vscode.commands.registerCommand(OctCommands.FollowPeer, (peer?: PeerWithColor) => this.followService.followPeer(peer?.id)),
+            vscode.commands.registerCommand(OctCommands.StopFollowPeer, () => this.followService.unfollowPeer()),
+            vscode.commands.registerCommand(OctCommands.Enter, async () => {
+                await this.openMainQuickpick();
             }),
-            vscode.commands.registerCommand('oct.joinRoom', async () => {
+            vscode.commands.registerCommand(OctCommands.JoinRoom, async () => {
                 await this.roomService.joinRoom();
             }),
-            vscode.commands.registerCommand('oct.createRoom', async () => {
+            vscode.commands.registerCommand(OctCommands.CreateRoom, async () => {
                 await this.roomService.createRoom();
             }),
-            vscode.commands.registerCommand('oct.closeConnection', async () => {
+            vscode.commands.registerCommand(OctCommands.CloseConnection, async () => {
                 const instance = CollaborationInstance.Current;
                 if (instance) {
                     await instance.leave();
@@ -120,12 +59,12 @@ export class Commands {
                     this.contextKeyService.setConnection(undefined);
                     if (!instance.host) {
                         // Close the workspace if the user is not the host
-                        await vscode.commands.executeCommand('workbench.action.closeFolder');
+                        await vscode.commands.executeCommand(CodeCommands.CloseFolder);
                     }
                 }
             }),
-            vscode.commands.registerCommand('oct.signOut', async () => {
-                await vscode.commands.executeCommand('oct.closeConnection');
+            vscode.commands.registerCommand(OctCommands.SignOut, async () => {
+                await vscode.commands.executeCommand(OctCommands.CloseConnection);
                 await this.secretStorage.deleteUserTokens();
                 vscode.window.showInformationMessage(vscode.l10n.t('Signed out successfully!'));
             })
@@ -133,7 +72,7 @@ export class Commands {
         if (typeof process === 'object' && process && process.env?.DEVELOPMENT === 'true') {
             this.contextKeyService.set('oct.dev', true);
             this.context.subscriptions.push(
-                vscode.commands.registerCommand('oct.dev.fuzzing', async () => {
+                vscode.commands.registerCommand(OctCommands.DevFuzzing, async () => {
                     const editor = vscode.window.activeTextEditor;
                     // Generate random character a-z
                     const char = String.fromCharCode(Math.floor(Math.random() * 26) + 97);
@@ -152,6 +91,116 @@ export class Commands {
                 })
             );
         }
-        this.statusService.initialize('oct.enter');
+        this.statusService.initialize(OctCommands.Enter);
+    }
+
+    private async openMainQuickpick(): Promise<void> {
+        const instance = CollaborationInstance.Current;
+        if (instance) {
+            await this.openMainQuickpickInSession(instance);
+        } else {
+            await this.openMainQuickpickOutsideSession();
+        }
+    }
+
+    private async openMainQuickpickOutsideSession(): Promise<void> {
+        const items: QuickPickItem<'join' | 'create'>[] = [
+            {
+                key: 'join',
+                label: '$(vm-connect) ' + vscode.l10n.t('Join Collaboration Session'),
+                detail: vscode.l10n.t('Join an open collaboration session using an invitation code')
+            }
+        ];
+        if (vscode.workspace.workspaceFolders?.length) {
+            items.unshift({
+                key: 'create',
+                label: '$(add) ' + vscode.l10n.t('Create New Collaboration Session'),
+                detail: vscode.l10n.t('Become the host of a new collaboration session in your current workspace')
+            });
+        }
+        const index = await showQuickPick(items, {
+            placeholder: vscode.l10n.t('Select Collaboration Option')
+        });
+        if (index === 'create') {
+            await this.roomService.createRoom();
+        } else if (index === 'join') {
+            await this.roomService.joinRoom();
+        }
+    }
+
+    private async openMainQuickpickInSession(instance: CollaborationInstance): Promise<void> {
+        const items: QuickPickItem<'invite' | 'stop' | 'update'>[] = [
+            {
+                key: 'invite',
+                label: '$(clippy) ' + vscode.l10n.t('Invite Others (Copy Code)'),
+                detail: vscode.l10n.t('Copy the invitation code to the clipboard to share with others')
+            }
+        ];
+        if (instance.host) {
+            items.push({
+                key: 'update',
+                label: '$(gear) ' + vscode.l10n.t('Configure Collaboration Session'),
+                detail: vscode.l10n.t('Configure the options and permissions of the current session')
+            });
+            items.push({
+                key: 'stop',
+                label: '$(circle-slash) ' + vscode.l10n.t('Stop Collaboration Session'),
+                detail: vscode.l10n.t('Stop the collaboration session, stop sharing all content and remove all participants')
+            });
+        } else {
+            items.push({
+                key: 'stop',
+                label: '$(circle-slash) ' + vscode.l10n.t('Leave Collaboration Session'),
+                detail: vscode.l10n.t('Leave the collaboration session, closing the current workspace')
+            });
+        }
+        const result = await showQuickPick(items, {
+            placeholder: vscode.l10n.t('Select Collaboration Option')
+        });
+        if (result === 'invite') {
+            await this.inviteCallback(instance);
+        } else if (result === 'update') {
+            await this.updatePermissions(instance);
+        } else if (result === 'stop') {
+            await vscode.commands.executeCommand(OctCommands.CloseConnection);
+        }
+    }
+
+    async inviteCallback(instance: CollaborationInstance): Promise<void> {
+        vscode.env.clipboard.writeText(instance.roomId);
+        const copyWithServer = vscode.l10n.t('Copy with Server URL');
+        vscode.window.showInformationMessage(vscode.l10n.t('Invitation code {0} copied to clipboard!', instance.roomId), copyWithServer).then(value => {
+            if (value === copyWithServer) {
+                vscode.env.clipboard.writeText(RoomUri.create({
+                    roomId: instance.roomId,
+                    serverUrl: instance.serverUrl
+                }));
+            }
+        });
+    }
+
+    async updatePermissions(instance: CollaborationInstance): Promise<void> {
+        const permissions: QuickPickItem<'readonly' | 'readwrite'>[] = [];
+        if (instance.permissions.readonly) {
+            permissions.push({
+                key: 'readwrite',
+                label: '$(unlock) ' + vscode.l10n.t('Enable Editing'),
+                detail: vscode.l10n.t('Allow all participants to edit files in the workspace')
+            });
+        } else {
+            permissions.push({
+                key: 'readonly',
+                label: '$(lock) ' + vscode.l10n.t('Make Read-Only'),
+                detail: vscode.l10n.t('Prevent all participants from editing the workspace')
+            });
+        }
+        const result = await showQuickPick(permissions, {
+            placeholder: vscode.l10n.t('Select Permissions')
+        });
+        if (result === 'readonly') {
+            instance.setPermissions({ readonly: true });
+        } else if (result === 'readwrite') {
+            instance.setPermissions({ readonly: false });
+        }
     }
 }


### PR DESCRIPTION
Related to https://github.com/eclipse-oct/open-collaboration-tools/issues/86

Works very similar to the MS Live share feature - the host can declare their workspace as readonly. Guests then immediately have their write rights revoked. Their VS Code instances will immediately re-register the file system provider and prevent further changes to the workspace.

In case any changes arrive nonetheless, the host simply ignores those changes.