### PR TITLE
Update dev container image

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -5,11 +5,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/oct-server
+  IMAGE_NAME: ${{ github.repository }}/oct-server-dev
 
 jobs:
   images:
-    name: oct-server image deploy
+    name: oct-server-dev image deploy
     runs-on: ubuntu-latest
 
     permissions:
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build and push Docker image
       id: push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
       with:
         context: .
         push: true
@@ -50,7 +50,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
         subject-digest: ${{ steps.push.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run start
 
 ## Deployment
 
-A container image named [oct-server](https://github.com/eclipse-oct/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server) is available for simple deployment. It does not require any additional infrastructure services. However, the server uses WebSocket connections and holds session data in memory, so horizontal scaling is not yet supported.
+A container image named [oct-server-dev](https://github.com/eclipse-oct/open-collaboration-tools/pkgs/container/open-collaboration-tools%2Foct-server-dev) is available for simple deployment. It does not require any additional infrastructure services. However, the server uses WebSocket connections and holds session data in memory, so horizontal scaling is not yet supported.
 
 Build the container image:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
-  oct-server:
+  oct-server-dev:
     build:
       dockerfile: ./Dockerfile
       context: .
-    image: oct/oct-server
+    image: oct/oct-server-dev
     ports:
       - 8100:8100
-    container_name: oct-server
+    container_name: oct-server-dev
     tty: true
     environment:
       - OCT_ACTIVATE_SIMPLE_LOGIN=true


### PR DESCRIPTION
Fixes #119 The image was never build after the repo moved to eclipse-oct. I changed the name to `oct-server-dev` as well.