### PR TITLE
Release VS Code client v0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10333,7 +10333,7 @@
     },
     "packages/open-collaboration-vscode": {
       "name": "open-collaboration-tools",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "~0.5.0",

--- a/packages/open-collaboration-vscode/CHANGELOG.md
+++ b/packages/open-collaboration-vscode/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Change Log of `open-collaboration-tools`
 
+## v0.3.1 (Apr. 2025)
+
+- Shared documents are now using normalized line endings (`\n`) to prevent cross-platform issues ([#127](https://github.com/eclipse-oct/open-collaboration-tools/pull/127)).
+
 ## v0.3.0 (Apr. 2025)
 
 - Session peers should now appear more consistently in the session view ([#40](https://github.com/eclipse-oct/open-collaboration-tools/pull/40)).
 - The extension will no longer corrupt multi-root workspaces ([#101](https://github.com/eclipse-oct/open-collaboration-tools/pull/101)).
 - Unverified login will now be handled inside of VS Code ([#98](https://github.com/eclipse-oct/open-collaboration-tools/pull/98)).
-- Refactored the resyncing mechanism to prevent desync ([#107](github.com/eclipse-oct/open-collaboration-tools/pull/107)).
+- Refactored the resyncing mechanism to prevent desync ([#107](https://github.com/eclipse-oct/open-collaboration-tools/pull/107)).
 - Support readonly workspace sessions ([#114](https://github.com/eclipse-oct/open-collaboration-tools/pull/114)).
 - Session codes can now contain the server URL ([#92](github.com/eclipse-oct/open-collaboration-tools/pull/92)).
 

--- a/packages/open-collaboration-vscode/LICENSE
+++ b/packages/open-collaboration-vscode/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 TypeFox GmbH
+Copyright 2024-2025 TypeFox GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "description": "Connect with others and live-share your code in real-time collaboration sessions",
   "publisher": "typefox",


### PR DESCRIPTION
Just updates our changelog to reflect the newly released version of the VS Code extension that also includes https://github.com/eclipse-oct/open-collaboration-tools/pull/127.