### PR TITLE
Added ability to leave current room and exposed the connection

### DIFF
--- a/packages/open-collaboration-monaco/src/collaboration-instance.ts
+++ b/packages/open-collaboration-monaco/src/collaboration-instance.ts
@@ -145,6 +145,14 @@ export class CollaborationInstance implements Disposable {
         this.documentDisposables.clear();
     }
 
+    leaveRoom() {
+        this.options.connection.room.leave();
+    }
+
+    getCurrentConnection(): ProtocolBroadcastConnection {
+        return this.options.connection;
+    }
+
     protected pushDocumentDisposable(path: string, disposable: Disposable) {
         let disposables = this.documentDisposables.get(path);
         if (!disposables) {

--- a/packages/open-collaboration-monaco/src/monaco-api.ts
+++ b/packages/open-collaboration-monaco/src/monaco-api.ts
@@ -35,13 +35,15 @@ export type UserData = {me: types.Peer, others: OtherUserData[]};
 export type MonacoCollabApi = {
     createRoom: () => Promise<string | undefined>
     joinRoom: (roomToken: string) => Promise<string | undefined>
+    leaveRoom: () => void
     login: () => Promise<string | undefined>
     isLoggedIn: () => boolean
     setEditor: (editor: monaco.editor.IStandaloneCodeEditor) => void
     getUserData: () => Promise<UserData | undefined>
     onUsersChanged: (evt: UsersChangeEvent) => void
     followUser: (id?: string) => void
-    getFollowedUser: () => string | undefined
+    getFollowedUser: () => string | undefined,
+    getCurrentConnection: () => types.ProtocolBroadcastConnection | undefined
 }
 
 export function monacoCollab(options: MonacoCollabOptions): MonacoCollabApi {
@@ -148,13 +150,15 @@ export function monacoCollab(options: MonacoCollabOptions): MonacoCollabApi {
     return {
         createRoom: doCreateRoom,
         joinRoom: doJoinRoom,
+        leaveRoom: () => instance?.leaveRoom(),
         login: doLogin,
         isLoggedIn: () => !!connectionProvider?.authToken,
         setEditor: doSetEditor,
         getUserData: doGetUserData,
         onUsersChanged: registerUserChangeHandler,
         followUser: doFollowUser,
-        getFollowedUser: doGetFollowedUser
+        getFollowedUser: doGetFollowedUser,
+        getCurrentConnection: () => instance?.getCurrentConnection(),
     };
 
 }


### PR DESCRIPTION
Exposing the connection should let users more easily send and react to their own messages 

A question in general, wouldn't it be nicer if the MonacoCollabApi would be a class? Also this currently only lets you have a single session at a time open, since ther can only be one instance.