### PR TITLE
Fix Keycloak Auth provider initialization

### DIFF
--- a/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
@@ -39,6 +39,7 @@ export class KeycloakOAuthEndpoint extends OAuthEndpoint {
         this.label = this.configuration.getValue('keycloak-client-label') ?? 'Keycloak';
 
         this.keycloakBaseUrl = `${this.host}/realms/${this.realm}`;
+        super.initialize();
     }
 
     getProtocolProvider(): AuthProvider {


### PR DESCRIPTION
Mini fix for the keycloak provider so it initializes the base url correctly again