### PR TITLE
Fix extension in Code-Server environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10664,7 +10664,7 @@
     },
     "packages/open-collaboration-vscode": {
       "name": "open-collaboration-tools",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "~0.5.0",

--- a/packages/open-collaboration-vscode/CHANGELOG.md
+++ b/packages/open-collaboration-vscode/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log of `open-collaboration-tools`
 
+## v0.3.4 (Jul. 2025)
+
+- Fixed the extension to work in Code-Server applications
+
+## v0.3.3 (Jun. 2025)
+
+- Updated our extension logo again
+
+## v0.3.2 (Jun. 2025)
+
+- Updated our extension logo to match the new OCT design
+
 ## v0.3.1 (Apr. 2025)
 
 - Shared documents are now using normalized line endings (`\n`) to prevent cross-platform issues ([#127](https://github.com/eclipse-oct/open-collaboration-tools/pull/127)).

--- a/packages/open-collaboration-vscode/package.json
+++ b/packages/open-collaboration-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-collaboration-tools",
   "displayName": "Open Collaboration Tools",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "description": "Connect with others and live-share your code in real-time collaboration sessions",
   "publisher": "typefox",

--- a/packages/open-collaboration-vscode/src/collaboration-room-service.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-room-service.ts
@@ -169,7 +169,7 @@ export class CollaborationRoomService {
                 }
                 return false;
             });
-            if (success && isWeb) {
+            if (success && isWeb()) {
                 // It seems like the web extension mode doesn't restart the extension host upon changing workspace folders
                 // However, force restarting the extension host by reloading the window removes the current workspace folders
                 // Therefore, we simply attempt to connect after a short delay after receiving the success signal

--- a/packages/open-collaboration-vscode/src/collaboration-status-service.ts
+++ b/packages/open-collaboration-vscode/src/collaboration-status-service.ts
@@ -62,7 +62,7 @@ export class CollaborationStatusService {
         this.statusBarItem.command = commandId;
         this.statusBarItem.tooltip = vscode.l10n.t('Start a collaboration session');
         this.statusBarItem.show();
-        if (isWeb) {
+        if (isWeb()) {
             // For some reason, VS Code simply "swallows" our status bar item when running in web mode.
             // This will attempt to show it again every 200ms. After 30s, we disable that again.
             const interval = setInterval(() => this.statusBarItem.show(), 200);

--- a/packages/open-collaboration-vscode/src/utils/system.ts
+++ b/packages/open-collaboration-vscode/src/utils/system.ts
@@ -6,4 +6,6 @@
 
 import * as vscode from 'vscode';
 
-export const isWeb = vscode.env.appRoot === '';
+export function isWeb(): boolean {
+    return !(typeof process === 'object' && Boolean(process.versions.node)) && vscode.env.uiKind === vscode.UIKind.Web;
+}

--- a/packages/open-collaboration-vscode/src/utils/workspace.ts
+++ b/packages/open-collaboration-vscode/src/utils/workspace.ts
@@ -40,7 +40,7 @@ export interface CodeWorkspaceFolder {
 
 export async function storeWorkspace(folders: Folder[], storageUri: vscode.Uri): Promise<vscode.Uri | undefined> {
     const canWrite = vscode.workspace.fs.isWritableFileSystem(storageUri.scheme);
-    if (!canWrite || isWeb) {
+    if (!canWrite || isWeb()) {
         return undefined;
     }
     try {


### PR DESCRIPTION
Closes https://github.com/eclipse-oct/open-collaboration-tools/issues/84 (probably)

Inspired by [this change](https://github.com/microsoft/vscode/pull/251688) in the VSCode repo which exhibited a similiar issue.