### PR TITLE
Add Authentik-based auth provider

### DIFF
--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -26,5 +26,8 @@ Environment variables
 | OCT_ACTIVATE_SIMPLE_LOGIN | Activates the simple login handler to alow unverified authentication just with username and optionally email |
 | OCT_OAUTH_{Provider Name}_CLIENTID | Sets the client id for the specified OAuth provider |
 | OCT_OAUTH_{Provider Name}_CLIENTSECRET | Sets the client secret for the specified OAuth provider |
+| OCT_OAUTH_{Provider Name}_URL | Sets the host URL for a custom (e.g. Authentik-based) OAuth provider |
+| OCT_OAUTH_{Provider Name}_USERNAMECLAIM | Sets the preferred username claim for an OAuth provider; defaults to `preferred_username` |
+| OCT_OAUTH_{Provider Name}_CLIENTLABEL | Sets a custom label for the specified OAuth provider |
 | OCT_REDIRECT_URL_WHITELIST | A comma seperated list to allow usage of the specified URLs with the `redirect` query parameter when authenticating with a provider which redirects back after success. The query of a URL is ignored when validating against this list   |
 | OCT_CORS_ALLOWED_ORIGINS | `,` seperated list to configure the allowed origins for CORS. This will be evaluated based on the origin header of the request. if there is no match, fail the request. if not set all origin will be allowed |

--- a/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
@@ -1,0 +1,103 @@
+// ******************************************************************************
+// Copyright 2025 TypeFox GmbH, n3therNet
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+import { AuthProvider } from 'open-collaboration-protocol';
+import { Strategy } from 'passport';
+import { OAuthEndpoint, ThirdParty } from './oauth-endpoint.js';
+import OAuth2Strategy, { VerifyCallback } from 'passport-oauth2';
+import { injectable, postConstruct } from 'inversify';
+
+@injectable()
+export class AuthentikOAuthEndpoint extends OAuthEndpoint {
+
+    protected override id: string = 'authentik';
+
+    protected override path: string = '/api/login/authentik';
+
+    protected override redirectPath: string = '/api/login/authentik-callback';
+
+    protected label: string = 'Authentik';
+
+    protected host?: string;
+    protected clientID?: string;
+    protected clientSecret?: string;
+    protected userNameClaim?: string;
+
+    @postConstruct()
+    init() {
+        this.host = this.configuration.getValue('OCT_OAUTH_AUTHENTIK_URL');
+        this.clientID = this.configuration.getValue('OCT_OAUTH_AUTHENTIK_CLIENTID');
+        this.clientSecret = this.configuration.getValue('OCT_OAUTH_AUTHENTIK_CLIENTSECRET');
+        this.userNameClaim = this.configuration.getValue('OCT_OAUTH_AUTHENTIK_USERNAMECLAIM');
+        this.label = this.configuration.getValue('OCT_OAUTH_AUTHENTIK_CLIENTLABEL') ?? 'Authentik';
+
+        super.initialize();
+    }
+
+    getProtocolProvider(): AuthProvider {
+        return {
+            endpoint: this.path,
+            name: this.label,
+            type: 'web',
+            label: {
+                code: '',
+                message: this.label,
+                params: []
+            },
+            group: ThirdParty
+        };
+    }
+
+    shouldActivate(): boolean {
+        return !!this.host && !!this.clientID;
+    }
+
+    getStrategy(host: string, port: number): Strategy {
+        return new AuthentikStrategy({
+            authorizationURL: `${this.host}/application/o/authorize/`,
+            tokenURL: `${this.host}/application/o/token/`,
+            userInfoURL: `${this.host}/application/o/userinfo/`,
+            clientID: this.clientID!,
+            clientSecret: this.clientSecret ?? '',
+            scope: ['openid', 'email', 'profile'],
+            callbackURL: this.createRedirectUrl(host, port, this.redirectPath),
+        }, (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback) => {
+            const userInfo = {
+                name: profile[this.userNameClaim ?? 'preferred_username'],
+                email: profile.email,
+                authProvider: this.label,
+            };
+            done(undefined, userInfo);
+        });
+
+    }
+
+}
+
+type AuthentikStrategyOptions = OAuth2Strategy.StrategyOptions & {
+    userInfoURL: string;
+}
+
+class AuthentikStrategy extends OAuth2Strategy {
+
+    constructor(protected options: AuthentikStrategyOptions, verify: OAuth2Strategy.VerifyFunction) {
+        super(options, verify);
+    }
+
+    override async userProfile(accessToken: string, done: (err?: unknown, profile?: any) => void): Promise<void> {
+        fetch(this.options.userInfoURL, {
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+        }).then(async response => {
+            if (!response.ok) {
+                throw new Error(`Failed to fetch user profile: ${response.statusText}`);
+            }
+            done(undefined, await response.json());
+        }).catch(err => done(err));
+
+    }
+}

--- a/packages/open-collaboration-server/src/index.ts
+++ b/packages/open-collaboration-server/src/index.ts
@@ -13,6 +13,7 @@ export * from './room-manager.js';
 export * from './types.js';
 export * from './user-manager.js';
 export * from './auth-endpoints/auth-endpoint.js';
+export * from './auth-endpoints/authentik-endpoint.js';
 export * from './auth-endpoints/keycloak-endpoint.js';
 export * from './auth-endpoints/oauth-endpoint.js';
 export * from './auth-endpoints/simple-login-endpoint.js';

--- a/packages/open-collaboration-server/src/inversify-module.ts
+++ b/packages/open-collaboration-server/src/inversify-module.ts
@@ -18,6 +18,7 @@ import { AuthEndpoint } from './auth-endpoints/auth-endpoint.js';
 import { GitHubOAuthEndpoint, GoogleOAuthEndpoint  } from './auth-endpoints/oauth-endpoint.js';
 import { Configuration, DefaultConfiguration } from './utils/configuration.js';
 import { PeerManager } from './peer-manager.js';
+import { AuthentikOAuthEndpoint } from './auth-endpoints/authentik-endpoint.js';
 import { KeycloakOAuthEndpoint } from './auth-endpoints/keycloak-endpoint.js';
 
 /**
@@ -48,6 +49,8 @@ export default new ContainerModule(bind => {
     bind(AuthEndpoint).toService(GitHubOAuthEndpoint);
     bind(GoogleOAuthEndpoint).toSelf().inSingletonScope();
     bind(AuthEndpoint).toService(GoogleOAuthEndpoint);
+    bind(AuthentikOAuthEndpoint).toSelf().inSingletonScope();
+    bind(AuthEndpoint).toService(AuthentikOAuthEndpoint);
     bind(KeycloakOAuthEndpoint).toSelf().inSingletonScope();
     bind(AuthEndpoint).toService(KeycloakOAuthEndpoint);
 });


### PR DESCRIPTION
Added [Authentik](https://goauthentik.io/) as auth provider following the pattern from keycloak, but with the correct ENV variables following the original pattern suggested by the docs.

New ENV vars:

* `OCT_OAUTH_AUTHENTIK_URL`
* `OCT_OAUTH_AUTHENTIK_USERNAMECLAIM`
* `OCT_OAUTH_AUTHENTIK_CLIENTLABEL`