### PR TITLE
Added service process release process

### DIFF
--- a/.github/workflows/release-service-process.yml
+++ b/.github/workflows/release-service-process.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 22.14.0
           cache: npm
 
-      - name: Install des pendencies
+      - name: Install dependencies
         run: npm ci
 
       - name: Build service-process executable

--- a/.github/workflows/release-service-process.yml
+++ b/.github/workflows/release-service-process.yml
@@ -1,0 +1,109 @@
+name: Release service-process binaries
+
+on:
+  push:
+    tags:
+      - service-process-v*
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: npm
+
+      - name: Install des pendencies
+        run: npm ci
+
+      - name: Build service-process executable
+        run: npm run create:executable --workspace=open-collaboration-service-process
+
+      - name: Prepare release artifact metadata
+        id: meta
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#service-process-v}"
+
+          case "${{ runner.os }}" in
+            Linux)
+              OS_NAME="linux"
+              EXT=""
+              ;;
+            Windows)
+              OS_NAME="windows"
+              EXT=".exe"
+              ;;
+            macOS)
+              OS_NAME="macos"
+              EXT=""
+              ;;
+            *)
+              echo "Unsupported OS: ${{ runner.os }}"
+              exit 1
+              ;;
+          esac
+
+          SOURCE="packages/open-collaboration-service-process/bin/oct-service-process${EXT}"
+          TARGET="oct-service-process-${VERSION}-${OS_NAME}-x64${EXT}"
+
+          if [ ! -f "$SOURCE" ]; then
+            echo "Expected binary not found: $SOURCE"
+            exit 1
+          fi
+
+          cp "$SOURCE" "$TARGET"
+          echo "asset_name=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.asset_name }}
+          path: ${{ steps.meta.outputs.asset_name }}
+          if-no-files-found: error
+
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build-binaries
+
+    steps:
+      - name: Download built binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
+      - name: Flatten artifact directories
+        shell: bash
+        run: |
+          mkdir -p dist
+          find release-assets -type f -exec cp {} dist/ \;
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          cd dist
+          sha256sum * > SHA256SUMS.txt
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*
+          generate_release_notes: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12118,7 +12118,7 @@
         "vscode-jsonrpc": "~8.2.1"
       },
       "bin": {
-        "oct-daemon-service": "bin/service"
+        "oct-service-process": "lib/bundle.cjs"
       },
       "engines": {
         "node": ">=20.10.0",

--- a/packages/open-collaboration-service-process/Readme.md
+++ b/packages/open-collaboration-service-process/Readme.md
@@ -74,3 +74,41 @@ Or sending Binary Data as a Parameter:
   ]
 }
 ```
+
+## Release
+
+Service process binaries are released through GitHub Actions.
+
+### Automated binary release
+
+The workflow `.github/workflows/release-service-process.yml` creates binaries for Linux, macOS, and Windows and publishes them to a GitHub Release.
+
+Trigger a release by pushing a tag in this format:
+
+```sh
+git tag service-process-v0.3.1
+git push origin service-process-v0.3.1
+```
+
+The workflow publishes:
+
+- `oct-service-process-<version>-linux-x64`
+- `oct-service-process-<version>-macos-x64`
+- `oct-service-process-<version>-windows-x64.exe`
+- `SHA256SUMS.txt`
+
+You can also run the workflow manually with `workflow_dispatch` from the Actions tab.
+
+### Build locally from source
+
+If you need to build the executable without downloading a release artifact:
+
+```sh
+npm ci
+npm run create:executable --workspace=open-collaboration-service-process
+```
+
+The executable is written to:
+
+- `packages/open-collaboration-service-process/bin/oct-service-process` on Linux and macOS
+- `packages/open-collaboration-service-process/bin/oct-service-process.exe` on Windows

--- a/packages/open-collaboration-service-process/Readme.md
+++ b/packages/open-collaboration-service-process/Readme.md
@@ -83,12 +83,7 @@ Service process binaries are released through GitHub Actions.
 
 The workflow `.github/workflows/release-service-process.yml` creates binaries for Linux, macOS, and Windows and publishes them to a GitHub Release.
 
-Trigger a release by pushing a tag in this format:
-
-```sh
-git tag service-process-v0.3.1
-git push origin service-process-v0.3.1
-```
+Trigger a release by pushing a tag in this format: `service-process-v0.3.1`
 
 The workflow publishes:
 

--- a/packages/open-collaboration-service-process/package.json
+++ b/packages/open-collaboration-service-process/package.json
@@ -4,9 +4,7 @@
   "license": "MIT",
   "description": "A service process for integrating non Typescript projects with the Open Collaboration Tools project",
   "files": [
-    "bin",
-    "lib",
-    "src"
+    "lib/bundle.cjs"
   ],
   "type": "module",
   "main": "./lib/messages.js",
@@ -25,12 +23,13 @@
     }
   },
   "bin": {
-    "oct-daemon-service": "./bin/service"
+    "oct-service-process": "./lib/bundle.cjs"
   },
   "scripts": {
     "start": "node lib/process.js",
     "start:direct": "tsx src/process.ts",
-    "build": "esbuild ./src/process.ts --bundle --platform=node --format=cjs --outfile=lib/bundle.cjs",
+    "build": "esbuild ./src/process.ts --bundle --platform=node --format=cjs --banner:js=\"#!/usr/bin/env node\" --outfile=lib/bundle.cjs",
+    "prepublishOnly": "npm run build",
     "create:executable": "npm run build && shx mkdir -p bin && node --experimental-sea-config sea-config.json && node scripts/sea-build.mjs"
   },
   "dependencies": {

--- a/packages/open-collaboration-service-process/scripts/sea-build.mjs
+++ b/packages/open-collaboration-service-process/scripts/sea-build.mjs
@@ -8,7 +8,8 @@ import { inject } from 'postject'
  * The resulting executable can be run as a standalone application without the need of nodejs being installed
  */
 
-var EXECUTABLE_NAME = 'oct-service-process'
+let EXECUTABLE_NAME = 'oct-service-process'
+const EXECUTABLE_PATH = `bin/${EXECUTABLE_NAME}`
 
 if (process.platform === 'win32') {
     EXECUTABLE_NAME = EXECUTABLE_NAME + '.exe'
@@ -20,7 +21,7 @@ if (process.platform === 'win32') {
 const postjectOptions = { sentinelFuse: 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2' }
 
 if (process.platform === 'darwin') {
-    execSync(`codesign --remove-signature ${EXECUTABLE_NAME}`)
+    execSync(`codesign --remove-signature ${EXECUTABLE_PATH}`)
     postjectOptions.machoSegmentName = 'NODE_SEA'
 }
 
@@ -29,5 +30,5 @@ console.log('injecting ', process.cwd() + '/bin/sea-prep.blob', 'into ', process
 inject(process.cwd() + '/bin/' + EXECUTABLE_NAME, 'NODE_SEA_BLOB', fs.readFileSync(process.cwd() + '/bin/sea-prep.blob'), postjectOptions)
 
 if (process.platform === 'darwin') {
-    execSync(`codesign --sign - ${EXECUTABLE_NAME}`)
+    execSync(`codesign --sign - ${EXECUTABLE_PATH}`)
 }


### PR DESCRIPTION
Adde a release process for the service process to create prebuild binaries

#### Improvements for later
maybe evaluate bun as runtime for smaller binaries. Because right the windows binary for example is ~90mb large
maybe evaluate [UPX](https://upx.github.io/) for reducing the binary size
maybe rather zip/targz the binaries for smaller binary sizes