### PR TITLE
Added yjs as direct dependency to the agent package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11905,7 +11905,6 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
       "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -11942,14 +11941,15 @@
       }
     },
     "packages/open-collaboration-agent": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.13.1",
         "commander": "~13.1.0",
         "dotenv": "^16.5.0",
         "open-collaboration-protocol": "~0.3.3",
-        "open-collaboration-yjs": "~0.3.0"
+        "open-collaboration-yjs": "~0.3.1",
+        "yjs": "^13.0.0"
       },
       "bin": {
         "oct-agent": "bin/agent"

--- a/packages/open-collaboration-agent/package.json
+++ b/packages/open-collaboration-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-collaboration-agent",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "description": "AI agent for the Open Collaboration Tools project",
   "files": [
@@ -40,7 +40,8 @@
     "commander": "~13.1.0",
     "dotenv": "^16.5.0",
     "open-collaboration-protocol": "~0.3.3",
-    "open-collaboration-yjs": "~0.3.0"
+    "open-collaboration-yjs": "~0.3.1",
+    "yjs": "^13.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.0",


### PR DESCRIPTION
installation via `npx open-collaboration-agent` didn't work because of a missing yjs dependency. It needed to be added directly in package.json. 