### PR TITLE
feat(server): support optional PKCE for generic OAuth

### DIFF
--- a/packages/open-collaboration-server/README.md
+++ b/packages/open-collaboration-server/README.md
@@ -50,3 +50,4 @@ currently supported providers are:
 | OCT_OAUTH_{Provider Name}_REALM | Sets the keycloak realm to use | keycloak |
 | OCT_OAUTH_USERINFO_URL | user info url if using oidc. If empty access token will be used for claims | generic |
 | OCT_OAUTH_TOKEN_URL | token url for code flow to retrieve the access token | generic |
+| OCT_OAUTH_PKCE | Enables S256 PKCE for the authorization code flow; defaults to `false` | generic |

--- a/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
@@ -9,6 +9,9 @@ import { Strategy } from 'passport';
 import { OAuthEndpoint } from './oauth-endpoint.js';
 import { injectable, postConstruct } from 'inversify';
 import OAuth2Strategy, { VerifyCallback } from 'passport-oauth2';
+import { createHash, randomBytes } from 'node:crypto';
+
+const PKCE_VERIFIER_TTL = 10 * 60 * 1000;
 
 @injectable()
 export class GenericOAuthEndpoint extends OAuthEndpoint {
@@ -25,6 +28,7 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
     protected clientSecret?: string;
     protected userNameClaim: string;
     protected userEmailClaim: string;
+    protected pkceEnabled: boolean;
 
     @postConstruct()
     init() {
@@ -38,6 +42,7 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
         this.clientSecret = this.configuration.getValue('oct-oauth-clientsecret');
         this.userNameClaim = this.configuration.getValue('oct-oauth-usernameclaim') ?? 'username';
         this.userEmailClaim = this.configuration.getValue('oct-oauth-emailclaim') ?? 'email';
+        this.pkceEnabled = this.configuration.getValue('oct-oauth-pkce', 'boolean') ?? false;
     }
 
     override getProtocolProvider(): AuthProvider {
@@ -64,6 +69,7 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
             clientSecret: this.clientSecret ?? '',
             userInfoURL: this.userInfoUrl!,
             callbackURL: this.createRedirectUrl(host, port, this.redirectPath),
+            pkceEnabled: this.pkceEnabled,
         };
 
         const verify = (accessToken: any, _: any, profile: any, done: VerifyCallback) => {
@@ -74,7 +80,7 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
             };
             done(undefined, userInfo);
         };
-        return this.userInfoUrl ? new OIDCStrategy(options, verify) : new OAuth2Strategy(options, verify);
+        return this.userInfoUrl ? new OIDCStrategy(options, verify) : new PKCEOAuth2Strategy(options, verify);
     }
 
     override getName(): string {
@@ -84,11 +90,70 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
 
 export type ODICOptions = OAuth2Strategy.StrategyOptions & {
     userInfoURL: string;
+    pkceEnabled?: boolean;
 }
 
-export class OIDCStrategy extends OAuth2Strategy {
+export type PKCEOAuth2Options = OAuth2Strategy.StrategyOptions & {
+    pkceEnabled?: boolean;
+}
 
-    constructor(protected options: ODICOptions, verify: OAuth2Strategy.VerifyFunction) {
+type PKCEVerifier = {
+    value: string;
+    timeout: NodeJS.Timeout;
+}
+
+export class PKCEOAuth2Strategy extends OAuth2Strategy {
+
+    protected readonly pkceVerifiers = new Map<string, PKCEVerifier>();
+
+    constructor(protected options: PKCEOAuth2Options, verify: OAuth2Strategy.VerifyFunction) {
+        super(options, verify);
+    }
+
+    override authorizationParams(options: Record<string, unknown>): object {
+        if (!this.options.pkceEnabled) {
+            return {};
+        }
+        const state = this.getState(options);
+        const value = randomBytes(32).toString('base64url');
+        const previousVerifier = this.pkceVerifiers.get(state);
+        if (previousVerifier) {
+            clearTimeout(previousVerifier.timeout);
+        }
+        const timeout = setTimeout(() => this.pkceVerifiers.delete(state), PKCE_VERIFIER_TTL);
+        timeout.unref();
+        this.pkceVerifiers.set(state, { value, timeout });
+        return {
+            code_challenge: createHash('sha256').update(value).digest('base64url'),
+            code_challenge_method: 'S256'
+        };
+    }
+
+    override tokenParams(options: Record<string, unknown>): object {
+        if (!this.options.pkceEnabled) {
+            return {};
+        }
+        const state = this.getState(options);
+        const verifier = this.pkceVerifiers.get(state);
+        if (!verifier) {
+            throw new Error('Missing or expired PKCE verifier for OAuth state');
+        }
+        this.pkceVerifiers.delete(state);
+        clearTimeout(verifier.timeout);
+        return { code_verifier: verifier.value };
+    }
+
+    protected getState(options: Record<string, unknown>): string {
+        if (typeof options.state !== 'string' || options.state.length === 0) {
+            throw new Error('PKCE requires a non-empty OAuth state');
+        }
+        return options.state;
+    }
+}
+
+export class OIDCStrategy extends PKCEOAuth2Strategy {
+
+    constructor(protected override options: ODICOptions, verify: OAuth2Strategy.VerifyFunction) {
         super(options, verify);
     }
 

--- a/packages/open-collaboration-server/test/auth-endpoints/generic-oauth-endpoint.test.ts
+++ b/packages/open-collaboration-server/test/auth-endpoints/generic-oauth-endpoint.test.ts
@@ -1,0 +1,62 @@
+// ******************************************************************************
+// Copyright 2026 TypeFox GmbH
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+// ******************************************************************************
+
+import { createHash } from 'node:crypto';
+import { describe, expect, test } from 'vitest';
+import OAuth2Strategy from 'passport-oauth2';
+import { PKCEOAuth2Strategy, PKCEOAuth2Options } from '../../src/auth-endpoints/generic-oauth-endpoint.js';
+
+const verify: OAuth2Strategy.VerifyFunction = (_accessToken, _refreshToken, _profile, done) => done(null, {});
+
+function createStrategy(pkceEnabled: boolean): PKCEOAuth2Strategy {
+    const options: PKCEOAuth2Options = {
+        authorizationURL: 'https://example.com/oauth/authorize',
+        tokenURL: 'https://example.com/oauth/token',
+        clientID: 'client-id',
+        clientSecret: 'client-secret',
+        callbackURL: 'https://oct.example.com/api/login/oauth-callback',
+        pkceEnabled
+    };
+    return new PKCEOAuth2Strategy(options, verify);
+}
+
+describe('Generic OAuth PKCE strategy', () => {
+    test('does not add PKCE parameters when disabled', () => {
+        const strategy = createStrategy(false);
+
+        expect(strategy.authorizationParams({ state: 'state' })).toEqual({});
+        expect(strategy.tokenParams({ state: 'state' })).toEqual({});
+    });
+
+    test('binds an S256 verifier to the OAuth state', () => {
+        const strategy = createStrategy(true);
+
+        const authorizationParams = strategy.authorizationParams({ state: 'state' }) as {
+            code_challenge: string;
+            code_challenge_method: string;
+        };
+        const tokenParams = strategy.tokenParams({ state: 'state' }) as { code_verifier: string };
+
+        expect(authorizationParams.code_challenge_method).toBe('S256');
+        expect(createHash('sha256').update(tokenParams.code_verifier).digest('base64url'))
+            .toBe(authorizationParams.code_challenge);
+    });
+
+    test('requires a non-empty OAuth state when enabled', () => {
+        const strategy = createStrategy(true);
+
+        expect(() => strategy.authorizationParams({})).toThrow('PKCE requires a non-empty OAuth state');
+        expect(() => strategy.tokenParams({ state: '' })).toThrow('PKCE requires a non-empty OAuth state');
+    });
+
+    test('consumes each verifier only once', () => {
+        const strategy = createStrategy(true);
+        strategy.authorizationParams({ state: 'state' });
+
+        expect(strategy.tokenParams({ state: 'state' })).toHaveProperty('code_verifier');
+        expect(() => strategy.tokenParams({ state: 'state' })).toThrow('Missing or expired PKCE verifier for OAuth state');
+    });
+});


### PR DESCRIPTION
## Why

Some OAuth authorization servers require PKCE for every authorization-code client, including confidential clients. The generic OAuth provider currently sends neither a code challenge during authorization nor a verifier during token exchange, which prevents those providers from being used with OCT.

## Changes

- add an opt-in `OCT_OAUTH_PKCE` configuration flag, disabled by default for backward compatibility
- generate an S256 code challenge and bind its verifier to the existing OAuth `state`
- expire abandoned verifiers after ten minutes and consume each verifier on its first token request
- keep the same behavior for both generic OAuth variants, with and without a user-info endpoint
- document the new environment variable and cover enabled, disabled, invalid-state, and single-use behavior

## Validation

- `npm run test -- --run packages/open-collaboration-server/test/auth-endpoints/generic-oauth-endpoint.test.ts` — 4 tests passed
- `npm run test -- --run` — 36 tests passed
- `npm run lint` — passed
- `npm run build` — passed, including TypeScript project references and all workspace builds

Closes #202